### PR TITLE
correction

### DIFF
--- a/_ark/ui/locale/fre/locale_updates_keep.dta
+++ b/_ark/ui/locale/fre/locale_updates_keep.dta
@@ -513,14 +513,14 @@
 (bleepbloops "Bleep Bloops")
 (solomedley "Solo Medleys")
 (bleepbloopuc "Bleep Bloop Undercharts")
-(customs "Chansons Custom")
+(customs "Chansons customs")
 (ugc_c3 "C3 Customs")
 (c3customs "C3 Customs")
 (c3legacy "C3 Legacy")
 (milohax "MiloHax Customs")
 (meme "Meme Songs")
-(ugc "Chansons Custom")
-(ugc_plus "Chansons Custom")
+(ugc "Chansons customs")
+(ugc_plus "Chansons customs")
 (ugc1 "Rock Band Network 1.0")
 (ugc2 "Rock Band Network 2.0")
 (ugc_lost "Lost Rock Band Network")
@@ -708,9 +708,9 @@
 (overshell_postproc
  "Désactiver Effets Concert")
 (the20s
-   "'Années 20")
+   "Années 20")
 (the2020s
-   "'Années 2020")
+   "Années 2020")
 (vocal_parts_0 "Pas de chant")
 (overshell_rb3esettings "Réglages RB3DX")
 (trackspeed_msg "VITESSE DES NOTES : %d%%")
@@ -783,7 +783,7 @@
 (nice_solo
    "Nice !")
 (choke_solo
-   "Solo quasi-parfait !")
+   "Solo quasi-parfait!")
 (token_redemption_error
    "Une erreur est survenue lors de l'obtention de ton bon. Réessaie ultérieurement.")
 #ifdef HX_PS3


### PR DESCRIPTION
A " ' " was in a the20s and the2020s traduction.
Correction of choke_solo.