### PR TITLE
Display RB3DX version in RB3Enhanced

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,7 @@ jobs:
           chmod +x dependencies/superfreq
           find . -name "*.*_ps3" -type f -delete
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/xbox/gen -n "patch_xbox" -e -v 6
       
       - name: Upload result
@@ -45,10 +42,7 @@ jobs:
           chmod +x dependencies/superfreq
           find . -name "*.*_xbox" -type f -delete
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/ps3/USRDIR/gen -n "patch_ps3" -e -v 6
       
       - name: Upload result
@@ -74,10 +68,7 @@ jobs:
           python dependencies/enable_keys.py
           find . -name "*.*_ps3" -type f -delete
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/xbox/gen -n "patch_xbox" -e -v 6
       
       - name: Upload result
@@ -103,10 +94,7 @@ jobs:
           pip install gitpython
           python dependencies/enable_keys.py
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/ps3/USRDIR/gen -n "patch_ps3" -e -v 6
       
       - name: Upload result
@@ -132,10 +120,7 @@ jobs:
           python dependencies/enable_animation.py
           find . -name "*.*_ps3" -type f -delete
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/xbox/gen -n "patch_xbox" -e -v 6
       
       - name: Upload result
@@ -161,10 +146,7 @@ jobs:
           pip install gitpython
           python dependencies/enable_animation.py
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/ps3/USRDIR/gen -n "patch_ps3" -e -v 6
       
       - name: Upload result
@@ -191,10 +173,7 @@ jobs:
           python dependencies/enable_keys.py
           find . -name "*.*_ps3" -type f -delete
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/xbox/gen -n "patch_xbox" -e -v 6
       
       - name: Upload result
@@ -221,10 +200,7 @@ jobs:
           python dependencies/enable_animation.py
           python dependencies/enable_keys.py
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/ps3/USRDIR/gen -n "patch_ps3" -e -v 6
       
       - name: Upload result
@@ -252,10 +228,7 @@ jobs:
           sed -i -e "s/(analog kControllerVocals)/(analog kControllerGuitar)/" _ark/config/joypad.dta
           sed -i -e "s/(dualshock kControllerVocals)/(dualshock kControllerGuitar)/" _ark/config/joypad.dta
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/xbox/gen -n "patch_xbox" -e -v 6
       
       - name: Upload result
@@ -283,10 +256,7 @@ jobs:
           sed -i -e "s/(analog kControllerVocals)/(analog kControllerGuitar)/" _ark/config/joypad.dta
           sed -i -e "s/(dualshock kControllerVocals)/(dualshock kControllerGuitar)/" _ark/config/joypad.dta
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/ps3/USRDIR/gen -n "patch_ps3" -e -v 6
       
       - name: Upload result
@@ -312,10 +282,7 @@ jobs:
           sed -i -e "s/(ro_drums_ps3_ghwt kControllerRealGuitar)/(ro_drums_ps3_ghwt kControllerDrum)/" _ark/config/joypad.dta
           sed -i -e "s/(konami_drums_ps3_rr kControllerKeys)/(konami_drums_ps3_rr kControllerDrum)/" _ark/config/joypad.dta
           echo $GITHUB_SHA_SHORT
-          sed -i -e "s/Rock Band 3 Deluxe devbuild geladen! Danke fürs spielen!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" geladen! Danke fürs spielen!/g" _ark/ui/locale/deu/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Loaded! Thanks for playing!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Loaded! Thanks for playing!/g" _ark/ui/locale/eng/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild Activado! ¡Gracias por Jugar!/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" Activado! ¡Gracias por Jugar!/g" _ark/ui/locale/esl/locale_updates_keep.dta
-          sed -i -e "s/Rock Band 3 Deluxe devbuild chargé ! Merci pour y jouer !/Rock Band 3 Deluxe commit: "$GITHUB_SHA_SHORT" chargé ! Merci pour y jouer !/g" _ark/ui/locale/fre/locale_updates_keep.dta
+          sed -i -e "s/devbuild/"$GITHUB_SHA_SHORT"/g" _ark/ui/locale/*/locale_updates_keep.dta
           dependencies/arkhelper dir2ark ./_ark ./_build/ps3/USRDIR/gen -n "patch_ps3" -e -v 6
 
       - name: Upload result

--- a/_ark/ui/locale/deu/locale_updates_keep.dta
+++ b/_ark/ui/locale/deu/locale_updates_keep.dta
@@ -857,6 +857,7 @@
 (mod_mirror_mode "Spiegel Modus (Nur Gitarre)")
 (mod_color_shuffle "Zufällige Gem Farben")
 (chmode_warning "Der Clone Hero Modus zwingt das Hit Window nachsichtiger zu sein. Speichern wird Deaktiviert und eine Nachricht wird dem Endbildschirm hinzugefügt, wenn du dies aktivierst.")
+(rb3e_mod_string "RB3DX devbuild")
 (breakneck_warning
   "Bitte deaktivier andere Modifikatoren für die Breakneck Geschwindigkeit bevor du diesen aktivierst.")
 (autoplay_warning

--- a/_ark/ui/locale/eng/locale_updates_keep.dta
+++ b/_ark/ui/locale/eng/locale_updates_keep.dta
@@ -857,6 +857,7 @@
 (mod_mirror_mode "Mirror Mode (Guitar Only)")
 (mod_color_shuffle "Gem Color Shuffle")
 (chmode_warning "Clone Hero Mode changes the hit window to be more lenient. Saving will be disabled and a message will be added to the end screen if you enable this.")
+(rb3e_mod_string "RB3DX devbuild")
 (breakneck_warning
   "Please disable other breakneck speed modifiers before enabling this one.")
 (autoplay_warning

--- a/_ark/ui/locale/esl/locale_updates_keep.dta
+++ b/_ark/ui/locale/esl/locale_updates_keep.dta
@@ -857,6 +857,7 @@
 (mod_mirror_mode "Modo Espejo (Solo Guitarra)")
 (mod_color_shuffle "Notas con Colores Aleatorios")
 (chmode_warning "El modo Clone Hero modifica la hit window para que sea menos severa. El autoguardado será desactivado y un mensaje se añadirá a la end screen si se activa.")
+(rb3e_mod_string "RB3DX devbuild")
 (breakneck_warning
  "Por favor deshabilite los demás modificadores de velocidad para activar este.")
 (autoplay_warning

--- a/_ark/ui/locale/fre/locale_updates_keep.dta
+++ b/_ark/ui/locale/fre/locale_updates_keep.dta
@@ -857,6 +857,7 @@
 (mod_mirror_mode "Mode Miroir (Guitare uniquement)")
 (mod_color_shuffle "Couleur des Gemmes Mélangé")
 (chmode_warning "Le Mode Clone Hero change la fenêtre d'action pour être plus indulgent. Les sauvegardes sont désactivés et un message va être ajouté à la fin si vous l'activez.")
+(rb3e_mod_string "RB3DX devbuild")
 (breakneck_warning
   "Veuiller désactiver les modifications de la vitesse folles avant d'activer celui-là.")
 (autoplay_warning


### PR DESCRIPTION
As of RB3Enhanced commit 503006a, the locale message `rb3e_mod_string` will show in the MOTD hooks done by RB3E.

This PR adds these messages to eng/fre/esl/deu locale_updates_keep.dta and updates the GitHub Actions build script to match (it now replaces all instances of `devbuild` with the commit, rather than per-language, and only runs 1 sed command rather than 4.)

(Tested using the Xbox actions build as well as the local build.)

![image](https://user-images.githubusercontent.com/22731889/192869254-13061d82-cbf8-4128-91ae-7bb7524db978.png)
