### PR TITLE
Fix a bug in _build_wii_nopause.bat

### DIFF
--- a/_ark/config/band_keep.dta
+++ b/_ark/config/band_keep.dta
@@ -18,7 +18,7 @@
    (alt_dirs
       #ifndef _SHIP
       #endif)
-   (max_song_count 32767)
+   (max_song_count 5000)
    #ifndef _SHIP
    (max_song_count_debug 180)
    #endif)

--- a/_build_wii_nopause.bat
+++ b/_build_wii_nopause.bat
@@ -5,4 +5,4 @@ copy "%~dp0\_build\wii_rebuild_files\main_wii_10.ark" "%~dp0\_build\wii"
 move "%~dp0\_build\wii\gen\main_wii.hdr" "%~dp0\_build\wii"
 move "%~dp0\_build\wii\gen\main_wii_10.ark" "%~dp0\_build\wii"
 rmdir "%~dp0\_build\wii\gen"
-pause
+

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This Repo contains everything you need to build an ark for Rock Band 3 Deluxe fo
 ## Features
 
 ### Quality of Life
-* Max song limit increased to 32767. Tested up to 2k (twice default) On a real Wii
+* Max song limit increased to 5000. Tested up to 2k (twice default) On a real Wii
 * Song select ambient noise modifier, default disabled
 * New menu, "RB3DX Menu", in game for additional modifications
 * Selectable song speed and track speed by 5% increments


### PR DESCRIPTION
I forgot to remove the pause

And also it decreases the max song count to 5000 on Wii because c0cf75b hasn't been merged into Wii yet