### PR TITLE
Fix lefty drums gem colors.

### DIFF
--- a/_ark/config/track_graphics.dta
+++ b/_ark/config/track_graphics.dta
@@ -173,45 +173,69 @@
    (unison unison_mask.wid))
 #define DRUM_LEFTY
 ((0
-      (normal gem_kick.wid)
+      (normal
+         {elem
+            (KICK_SET)
+            $kick_color})
       (star star_kick.wid)
       (unison star_kick.wid)
       (miss kick_miss.wid))
    (1
-      (normal drum_green.wid)
+      (normal
+         {elem
+            (DRUMGEM_SET)
+            $drum4_color})
       (star drum_star.wid)
       (unison drum_star.wid)
       (miss drum_miss.wid)
       (fill drum_mash4.wid)
       (mash drum_roll4.wid)
-      (normal_cymbal cymbal_gem_green.wid)
+      (normal_cymbal
+         {elem
+            (CYM_SET)
+            $cym4_color})
       (miss_cymbal cymbal_gem_miss.wid)
       (star_cymbal cymbal_gem_star.wid)
       (unison_cymbal cymbal_gem_star.wid))
    (2
-      (normal drum_blue.wid)
+      (normal
+         {elem
+            (DRUMGEM_SET)
+            $drum3_color})
       (star drum_star.wid)
       (unison drum_star.wid)
       (miss drum_miss.wid)
       (fill drum_mash3.wid)
       (mash drum_roll3.wid)
-      (normal_cymbal cymbal_gem_blue.wid)
+      (normal_cymbal
+         {elem
+            (CYM_SET)
+            $cym3_color})
       (miss_cymbal cymbal_gem_miss.wid)
       (star_cymbal cymbal_gem_star.wid)
       (unison_cymbal cymbal_gem_star.wid))
    (3
-      (normal drum_yellow.wid)
+      (normal
+         {elem
+            (DRUMGEM_SET)
+            $drum2_color})
       (star drum_star.wid)
       (unison drum_star.wid)
       (miss drum_miss.wid)
       (fill drum_mash2.wid)
       (mash drum_roll2.wid)
-      (normal_cymbal cymbal_gem_yellow.wid)
+      (normal_cymbal
+         {elem
+            (CYM_SET)
+            $cym2_color})
       (miss_cymbal cymbal_gem_miss.wid)
       (star_cymbal cymbal_gem_star.wid)
       (unison_cymbal cymbal_gem_star.wid))
    (4
-      (normal drum_red.wid)
+      (normal
+         {elem
+            (DRUMGEM_SET)
+            $drum1_color})
       (star drum_star.wid)
       (unison drum_star.wid)
       (miss drum_miss.wid)
@@ -220,7 +244,10 @@
       (crash_cymbal dynamic_crash_gem_cymbal_lefty.wid)
       (beard dynamic_crash_beard_lefty.wid)
       (mash drum_roll1.wid)
-      (normal_cymbal cymbal_gem_red.wid)
+      (normal_cymbal
+         {elem
+            (CYM_SET)
+            $cym1_color})
       (miss_cymbal cymbal_gem_miss.wid)
       (star_cymbal cymbal_gem_star.wid)
       (unison_cymbal cymbal_gem_star.wid))


### PR DESCRIPTION
The gems work now but a future commit will need to fix the menu options for editing the colors of cymbal gems. The option for the 1st lane actually comes last which is strange.

Closes #130 