### PR TITLE
Hide dx settings when online

### DIFF
--- a/_ark/ui/overshell/overshell_dir.dta
+++ b/_ark/ui/overshell/overshell_dir.dta
@@ -229,7 +229,8 @@
                {push_back $options overshell_av_settings}
                {push_back $options overshell_extras}
                {push_back $options overshell_modifiers}
-                  {push_back $options overshell_rb3esettings}
+			   {if {! $online_enabled}
+                  {push_back $options overshell_rb3esettings}}
                {game_options.lst set_data $options}})
          (set_platform
             ($platform)


### PR DESCRIPTION
To prevent accidentally crashing others