### PR TITLE
enable pro drums for all drum controllers

### DIFF
--- a/_ark/ui/overshell/slot_states.dta
+++ b/_ark/ui/overshell/slot_states.dta
@@ -3913,6 +3913,11 @@
    (overshell_guitar
     overshell_bass
     overshell_keys)}}
+      {if {== {{$this get_user} get_controller_type} kControllerDrum}
+  {choose_part.lst
+   set_data
+   (overshell_drums
+    overshell_drums_pro)}}
       {if {== {{$this get_user} get_controller_type} kControllerVocals}
   {choose_part.lst
    set_data


### PR DESCRIPTION
Turns out pro drums can work on guitar hero drums with just the green cymbal enabled. Might as well make it an option for those using stock instrument mapping.