### PR TITLE
RB1/2 DLC naming consistency with RB3/4

### DIFF
--- a/_ark/ui/locale/deu/locale_updates_keep.dta
+++ b/_ark/ui/locale/deu/locale_updates_keep.dta
@@ -526,7 +526,7 @@
 (ugc1 "Rock Band Network 1.0")
 (ugc2 "Rock Band Network 2.0")
 (ugc_lost "Rock Band Network (Verlorengegangen)")
-(rb1_dlc "Rock Band Downloadable Content")
+(dlc "Rock Band 1/2 DLC")
 (rb3dlc "Rock Band 3 DLC")
 (rb4dlc "Rock Band 4 DLC")
 (rb4_dlc "Rock Band 4 DLC")

--- a/_ark/ui/locale/eng/locale_updates_keep.dta
+++ b/_ark/ui/locale/eng/locale_updates_keep.dta
@@ -537,7 +537,7 @@
 (ugc1 "Rock Band Network 1.0")
 (ugc2 "Rock Band Network 2.0")
 (ugc_lost "Lost Rock Band Network")
-(rb1_dlc "Rock Band Downloadable Content")
+(dlc "Rock Band 1/2 DLC")
 (rb3dlc "Rock Band 3 DLC")
 (rb4dlc "Rock Band 4 DLC")
 (rb4_dlc "Rock Band 4 DLC")

--- a/_ark/ui/locale/esl/locale_updates_keep.dta
+++ b/_ark/ui/locale/esl/locale_updates_keep.dta
@@ -526,7 +526,7 @@
 (ugc1 "Rock Band Network 1.0")
 (ugc2 "Rock Band Network 2.0")
 (ugc_lost "Lost Rock Band Network")
-(rb1_dlc "Rock Band Downloadable Content")
+(dlc "Rock Band 1/2 DLC")
 (rb3dlc "Rock Band 3 DLC")
 (rb4dlc "Rock Band 4 DLC")
 (rb4_dlc "Rock Band 4 DLC")

--- a/_ark/ui/locale/fre/locale_updates_keep.dta
+++ b/_ark/ui/locale/fre/locale_updates_keep.dta
@@ -526,7 +526,7 @@
 (ugc1 "Rock Band Network 1.0")
 (ugc2 "Rock Band Network 2.0")
 (ugc_lost "Lost Rock Band Network")
-(rb1_dlc "Rock Band Downloadable Content")
+(dlc "Rock Band 1/2 DLC")
 (rb3dlc "Rock Band 3 DLC")
 (rb4dlc "Rock Band 4 DLC")
 (rb4_dlc "Rock Band 4 DLC")


### PR DESCRIPTION
Replaces "Downloaded Songs" with "Rock Band 1/2 DLC" for parity with older versions' "Rock Band Downloadable Content", as well as consistency with the current "Rock Band 3 DLC" and "Rock Band 4 DLC".