### PR TITLE
remove all instruments mode from modifier saving

### DIFF
--- a/_ark/ui/init.dta
+++ b/_ark/ui/init.dta
@@ -713,11 +713,6 @@
 #define INIT_MOD_READER
 (
    {foreach $entry {read_file #ifdef HX_XBOX "GAME:/mod.dta" #endif #ifdef HX_PS3 "GD:/dev_hdd0/game/BLUS30463/USRDIR/mod.dta" #endif}
-      {if {== {elem $entry 0} {basename mod_auto_vocals}}
-         {if {== {elem {find $entry mod_auto_vocals} 1} 1}
-            {modifier_mgr toggle_modifier_enabled mod_auto_vocals}
-         }
-      }
       {if {== {elem $entry 0} {basename mod_staticfills}}
          {if {== {elem {find $entry mod_staticfills} 1} 1}
             {modifier_mgr toggle_modifier_enabled mod_staticfills}

--- a/_ark/ui/main/main_hub.dta
+++ b/_ark/ui/main/main_hub.dta
@@ -212,9 +212,6 @@
             (mod_doublespeed
               (mod_doublespeed {if_else {modifier_mgr is_modifier_active mod_doublespeed} TRUE FALSE})
             )
-            (mod_auto_vocals
-              (mod_auto_vocals {if_else {modifier_mgr is_modifier_active mod_auto_vocals} TRUE FALSE})
-            )
             (mod_staticfills
                (mod_staticfills {if_else {modifier_mgr is_modifier_active mod_staticfills} TRUE FALSE})
             )


### PR DESCRIPTION
having it save is pointless anyway as the game asks you upon boot if you want to enable it if you have 4 laned instruments connected