### PR TITLE
Rotate venues modifier, sync venues with host

### DIFF
--- a/_ark/config/modifiers.dta
+++ b/_ark/config/modifiers.dta
@@ -38,6 +38,7 @@
    (mod_nointro) ;skips intro players cutscene on song start (do not allow online)
    (mod_nopause) ; mimics party mode in rb4 allowing quick drop ins and outs without pausing
    (mod_nomv) ; no music video venues will be randomly picked
+   (mod_venue_swap) ; changes venue after every song mid-setlist
    (mod_no_crowd_meter custom_location) ; no crowd meter in game
    (mod_no_scoreboard custom_location) ; no scoreboard in game
    (mod_practiceoverdrive) ; allows the gaining and deploying of over drive in practice mode (disables select to restart)

--- a/_ark/dx/macros/dx_game_macros.dta
+++ b/_ark/dx/macros/dx_game_macros.dta
@@ -105,59 +105,36 @@
 (
    {dx_log_writer {sprint "Setting Venue - Current Screen: " {ui current_screen} " - Gamemode: " $dx_gamemode}}
    {if
-      {||
-         {gamemode in_mode defaults} {gamemode in_mode qp_party_shuffle}
-         {gamemode in_mode qp_coop} {gamemode in_mode party_shuffle}
-         {gamemode in_mode practice} {gamemode in_mode qp_practice}
-      }
-      {if_else {== $force TRUE} ;prioritizes a forced venue over the no music video modifier
-         {if_else {== $venue small_venues}
-            {do
-               {gamecfg set_venue {random_elem (SMALL_VENUES)}}
-               {meta_performer set_venue {random_elem (SMALL_VENUES)}}
-            }
-            {if_else {== $venue big_venues}
-               {do
-                  {gamecfg set_venue {random_elem (BIG_VENUES)}}
-                  {meta_performer set_venue {random_elem (BIG_VENUES)}}
-               }
-               {if_else {== $venue arena_venues}
-                  {do
-                     {gamecfg set_venue {random_elem (ARENA_VENUES)}}
-                     {meta_performer set_venue {random_elem (ARENA_VENUES)}}
-                  }
-                  {if_else {== $venue festival_venues}
-                     {do
-                        {gamecfg set_venue {random_elem (FESTIVAL_VENUES)}}
-                        {meta_performer set_venue {random_elem (FESTIVAL_VENUES)}}
-                     }
-                     {if_else {== $venue venues_video}
-                        {do
-                           {gamecfg set_venue {random_elem (VENUES_VIDEO)}}
-                           {meta_performer set_venue {random_elem (VENUES_VIDEO)}}
-                        }
-                        {if_else {&& {== $venue random} {! {modifier_mgr is_modifier_active mod_nomv}}}
-                           {do
-                              {gamecfg set_venue {random_elem (ALL_VENUES)}}
-                              {meta_performer set_venue {random_elem (ALL_VENUES)}}
-                           }
-                           {if_else {&& {== $venue random} {modifier_mgr is_modifier_active mod_nomv} {session_mgr is_leader_local}}
-                              {do
-                                 {gamecfg set_venue {random_elem (VENUES)}}
-                                 {meta_performer set_venue {random_elem (VENUES)}}
-                              }
-                              {do
-                                 {gamecfg set_venue $venue}
-                                 {meta_performer set_venue $venue}
-                              }
-                           }
-                        }
-                     }
-                  }
-               }
-            }
+      {&&
+         {||
+            {gamemode in_mode defaults} {gamemode in_mode qp_party_shuffle}
+            {gamemode in_mode qp_coop} {gamemode in_mode party_shuffle}
+            {gamemode in_mode practice} {gamemode in_mode qp_practice}
          }
-         {if_else {&& {modifier_mgr is_modifier_active mod_nomv} {session_mgr is_leader_local}}
+         {session_mgr is_leader_local} ;set venue only if host of the lobby
+      }
+      {if_else {== $force TRUE}
+         {switch $venue
+            (small_venues {do {gamecfg set_venue {random_elem (SMALL_VENUES)}} {meta_performer set_venue {random_elem (SMALL_VENUES)}}})
+            (big_venues {do {gamecfg set_venue {random_elem (BIG_VENUES)}} {meta_performer set_venue {random_elem (BIG_VENUES)}}})
+            (arena_venues {do {gamecfg set_venue {random_elem (ARENA_VENUES)}} {meta_performer set_venue {random_elem (ARENA_VENUES)}}})
+            (festival_venues {do {gamecfg set_venue {random_elem (FESTIVAL_VENUES)}} {meta_performer set_venue {random_elem (FESTIVAL_VENUES)}}})
+            (venues_video {do {gamecfg set_venue {random_elem (VENUES_VIDEO)}} {meta_performer set_venue {random_elem (VENUES_VIDEO)}}})
+            (random
+               {if_else {! {modifier_mgr is_modifier_active mod_nomv}}
+                   {do
+                      {gamecfg set_venue {random_elem (ALL_VENUES)}}
+                      {meta_performer set_venue {random_elem (ALL_VENUES)}}
+                   }
+                   {do
+                      {gamecfg set_venue {random_elem (VENUES)}}
+                      {meta_performer set_venue {random_elem (VENUES)}}
+                   }
+               }
+            )
+            {do {gamecfg set_venue $venue} {meta_performer set_venue $venue}}
+         }
+         {if_else {modifier_mgr is_modifier_active mod_nomv}
             {do
                {gamecfg set_venue {random_elem (VENUES)}}
                {meta_performer set_venue {random_elem (VENUES)}}
@@ -170,6 +147,10 @@
       }
       {dx_log_writer {sprint "Venue set to " $venue " - Forced: " $force}}
    }
+)
+#define DX_SWAP_VENUE_MID_SETLIST
+(
+   {if {modifier_mgr is_modifier_active mod_venue_swap} DX_VENUE_SETTER}
 )
 #define DX_GAMEMODE_CHECKER
 (

--- a/_ark/dx/macros/dx_reader_macros.dta
+++ b/_ark/dx/macros/dx_reader_macros.dta
@@ -898,6 +898,7 @@
    {dx_modifier_reader mod_nolanes}
    {dx_modifier_reader mod_rb4lanes}
    {dx_modifier_reader mod_nomv}
+   {dx_modifier_reader mod_venue_swap}
    {dx_modifier_reader mod_nointro}
    {dx_modifier_reader mod_nosfx}
    {dx_modifier_reader mod_synced_track_speeds}
@@ -950,6 +951,9 @@
             )
             (mod_nomv
                (mod_nomv {modifier_mgr is_modifier_active mod_nomv})
+            )
+            (mod_venue_swap
+               (mod_venue_swap {modifier_mgr is_modifier_active mod_venue_swap})
             )
             (mod_nointro
                (mod_nointro {modifier_mgr is_modifier_active mod_nointro})

--- a/_ark/ui/endgame/endgame.dta
+++ b/_ark/ui/endgame/endgame.dta
@@ -13,6 +13,7 @@
    ENDGAME_PANEL_HANDLERS
    (enter DX_PRESENCE_MANGER
       DX_AUTO_ENDGAME
+      DX_SWAP_VENUE_MID_SETLIST
       {platform_mgr set_notify_ui_location kOSNotifyBottomCenter}
       {$this set_results}
       {overshell set_use_extended_mic_arrows TRUE}

--- a/_ark/ui/locale/locale_dx_keep.dta
+++ b/_ark/ui/locale/locale_dx_keep.dta
@@ -404,6 +404,7 @@
 (mod_practiceoverdrive "Overdrive in Practice")
 (mod_nolanes "No Lanes")
 (mod_rb4lanes "RB4 Lane Behavior")
+(mod_venue_swap "Rotate Venues")
 (mod_nomv "No Music Videos")
 (mod_noblur "No Motion Blur")
 (mod_nocrust "No Film Grain")
@@ -521,6 +522,7 @@
 (mod_dx_showbpm "Show Song BPM")
 (chmode_warning "Drunk Mode changes the hit window to be more lenient. Saving will be disabled and a message will be added to the end screen if you enable this.")
 (rb3e_mod_string "RB3DX devbuild")
+(os_venue_select_warn "Venue Selection will only take effect if you're the host of the lobby")
 (breakneck_warning
   "Please disable other breakneck speed modifiers before enabling this one.")
 (autoplay_warning
@@ -1218,6 +1220,7 @@
 (mod_auto_kick_desc "Don't have a kick pedal? No problem!")
 (mod_fakejuke_desc "Watch your band rock out!")
 (mod_auto_play_desc "Ruin the leaderboards and your credibility all at once!")
+(mod_venue_swap_desc "Get a new venue after every song mid-setlist")
 (os_currentsong
    "Display")
 (os_prefix_disable

--- a/_ark/ui/overshell/dx_states.dta
+++ b/_ark/ui/overshell/dx_states.dta
@@ -54,6 +54,9 @@
 (kState_RB3EVenueSelector
    (view #ifdef HX_WII options #else online_options #endif)
    (enter
+      DX_OS_OPEN_MSG
+      {set $dx_menu_message os_venue_select_warn}
+      DX_MENU_DESC
       {do
          ($venue_array
             {array
@@ -92,13 +95,15 @@
             {set $force TRUE} {set $venue venues_video} {ui goto_screen meta_loading_main_screen})
          (none
             {set $force TRUE} {set $venue BLACK_VENUE} {ui goto_screen meta_loading_main_screen})}
+      DX_OS_CLOSE_MSG
       {$this show_state kState_RB3ESettings} {ui pop_screen})
   (exit
   {#ifdef HX_WII options.lst #else online_options.lst #endif set circular 0}
   {#ifdef HX_WII options.lst #else online_options.lst #endif set_selected 0})
   (on_cancel
-  {options.lst set_selected 2}
-  {$this show_state kState_RB3ESettings}))
+      DX_OS_CLOSE_MSG
+      {options.lst set_selected 2}
+      {$this show_state kState_RB3ESettings}))
 
 ;save warnings
 


### PR DESCRIPTION
- Added a modifier to make the venue changes after every song mid-setlist
![image1](https://i.imgur.com/FLlpIxu.png)
- Only the host of the lobby can set the venue now
- Added a warning letting users know only the host can set the venue
![image2](https://i.imgur.com/lISpc11.png)
- Switched DX_VENUE_SETTER to switch statements