### PR TITLE
Wii mix for electric version keys upgrade

### DIFF
--- a/_ark/songs/dta_sections/custom_strings_and_keys_combined.dta
+++ b/_ark/songs/dta_sections/custom_strings_and_keys_combined.dta
@@ -2149,7 +2149,7 @@
    (real_bass_tuning (0 0 0 0))
    (strings_author "RK")
    (version 30))
-(electricversion   ; Not available on Wii.
+(electricversion   ;Not available on Wii.
    (upgrade_version 1) (extra_authoring disc_update)
    ;(midi_file "songs_upgrades/electricversion_plus.mid")
    ;(song_id 12)

--- a/_ark/songs/dta_sections/custom_strings_and_keys_combined.dta
+++ b/_ark/songs/dta_sections/custom_strings_and_keys_combined.dta
@@ -2149,11 +2149,24 @@
    (real_bass_tuning (0 0 0 0))
    (strings_author "RK")
    (version 30))
-(electricversion
+(electricversion   ; Not available on Wii.
    (upgrade_version 1) (extra_authoring disc_update)
    ;(midi_file "songs_upgrades/electricversion_plus.mid")
    ;(song_id 12)
    (song
+      #ifdef HX_WII
+      (tracks
+         ((drum
+            (0 1)) ;Downmix drums to stereo.
+         (bass 2)
+         (guitar
+            (3 4))
+         (vocals
+            (5 6))
+         (keys
+            (7 8)))
+      )
+      #else
       (tracks
          ((drum
             (0 1 2 3 4))
@@ -2165,6 +2178,7 @@
          (keys
             (10 11)))
       )
+      #endif
       (drum_solo
          (seqs
             (kick.cue snare.cue tom1.cue tom2.cue crash.cue)))


### PR DESCRIPTION
Untested.

This song doesn't normally exist on Wii, so I assume that customs, to get the song playable, will have drums downmixed to Stereo since the other drum mixes don't work on Wii anyway.
Try to remember going forward to grab the Wii mix for any keys upgrades (or DM me to get it for you if you can't be bothered).