### PR TITLE
Initial support for syncing online textures

### DIFF
--- a/_ark/config/modifiers.dta
+++ b/_ark/config/modifiers.dta
@@ -14,7 +14,7 @@
    (mod_miss_sounds default_enabled save_value delayed_effect) ; vanilla
    (mod_awesome save_value use_save_value) ;vanilla
    ;visual
-   (mod_remote_texture_sync default_enabled delayed_effect)
+   (mod_remote_texture_sync default_enabled delayed_effect) ; syncs custom track themes between online players
    (mod_mhx_color_shuffle #ifdef RB3E custom_location #endif) ; random gem coloring
    ; we should prefer rb3e's version of this modifier if it is present.
    ; we also need to use a different name so we don't conflict with rb3e

--- a/_ark/config/modifiers.dta
+++ b/_ark/config/modifiers.dta
@@ -14,6 +14,7 @@
    (mod_miss_sounds default_enabled save_value delayed_effect) ; vanilla
    (mod_awesome save_value use_save_value) ;vanilla
    ;visual
+   (mod_remote_texture_sync default_enabled)
    (mod_mhx_color_shuffle #ifdef RB3E custom_location #endif) ; random gem coloring
    ; we should prefer rb3e's version of this modifier if it is present.
    ; we also need to use a different name so we don't conflict with rb3e

--- a/_ark/config/modifiers.dta
+++ b/_ark/config/modifiers.dta
@@ -14,7 +14,7 @@
    (mod_miss_sounds default_enabled save_value delayed_effect) ; vanilla
    (mod_awesome save_value use_save_value) ;vanilla
    ;visual
-   (mod_remote_texture_sync default_enabled)
+   (mod_remote_texture_sync default_enabled delayed_effect)
    (mod_mhx_color_shuffle #ifdef RB3E custom_location #endif) ; random gem coloring
    ; we should prefer rb3e's version of this modifier if it is present.
    ; we also need to use a different name so we don't conflict with rb3e

--- a/_ark/dx/funcs/dx_game_reset_funcs.dta
+++ b/_ark/dx/funcs/dx_game_reset_funcs.dta
@@ -104,7 +104,7 @@
             {if {== $dx_vocal_highway "rock band 3"} {set $dx_vocal_highway none}}
             {if {== $dx_vocal_notes "rock band 3"} {set $dx_vocal_notes none}}
             {if {== $dx_vocal_overdrive "rock band 3"} {set $dx_vocal_overdrive none}}
-            {if {== $dx_keyboard classic} {set $dx_keyboard none}}
+            {if {== $dx_keyboard "rock band 3"} {set $dx_keyboard none}}
             {if {== $dx_highway_guitar _2_rb3_guitar} {set $dx_highway_guitar none}}
             {if {== $dx_highway_bass _rb3_bass} {set $dx_highway_bass none}}
             {if {== $dx_highway_drum _rb3_drum} {set $dx_highway_drum none}}

--- a/_ark/dx/locale/dx_locale_updates.dta
+++ b/_ark/dx/locale/dx_locale_updates.dta
@@ -537,6 +537,8 @@
 (mod_animatedgems "Animated Gems")
 (mod_dx_left_right_jump "Dpad Songlist Shortcuts")
 (mod_dx_left_right_jump_desc "Allows Left and Right on the dpad to jump up and down to the next section respectively")
+(mod_remote_texture_sync "Sync Online Textures")
+(mod_remote_texture_sync_desc "Show off each player's unique Highway/Streak/Overdrive in online sessions")
 (os_gems "Gems")
 (os_sustains "Sustains")
 (os_setguitarcol "Guitar Colors")

--- a/_ark/dx/locale/dx_version.dta
+++ b/_ark/dx/locale/dx_version.dta
@@ -1,4 +1,4 @@
-(message_motd "Rock Band 3 Deluxe v1.1 (devbuild) Loaded! Thanks for playing!")
-(message_motd_signin "Rock Band 3 Deluxe v1.1 (devbuild) Loaded! Thanks for playing!")
-(message_motd_noconnection "Rock Band 3 Deluxe v1.1 (devbuild) Loaded! Thanks for playing!")
-(rb3e_mod_string "RB3DX v1.1 (devbuild)")
+(message_motd "Rock Band 3 Deluxe v1.0.1 (devbuild) Loaded! Thanks for playing!")
+(message_motd_signin "Rock Band 3 Deluxe v1.0.1 (devbuild) Loaded! Thanks for playing!")
+(message_motd_noconnection "Rock Band 3 Deluxe v1.0.1 (devbuild) Loaded! Thanks for playing!")
+(rb3e_mod_string "RB3DX v1.0.1 (devbuild)")

--- a/_ark/dx/locale/dx_version.dta
+++ b/_ark/dx/locale/dx_version.dta
@@ -1,4 +1,4 @@
-(message_motd "Rock Band 3 Deluxe v1.0b Release Loaded! Thanks for playing!")
-(message_motd_signin "Rock Band 3 Deluxe v1.0b Release Loaded! Thanks for playing!")
-(message_motd_noconnection "Rock Band 3 Deluxe v1.0b Release Loaded! Thanks for playing!")
-(rb3e_mod_string "RB3DX v1.0b Release")
+(message_motd "Rock Band 3 Deluxe v1.1 Beta Loaded! Thanks for playing!")
+(message_motd_signin "Rock Band 3 Deluxe v1.1 Beta Loaded! Thanks for playing!")
+(message_motd_noconnection "Rock Band 3 Deluxe v1.1 Beta Loaded! Thanks for playing!")
+(rb3e_mod_string "RB3DX v1.1 Beta")

--- a/_ark/dx/macros/dx_reader_macros.dta
+++ b/_ark/dx/macros/dx_reader_macros.dta
@@ -613,9 +613,15 @@
       {set $dx_highway_guitar
          {elem {find $entry highway_guitar} 1}
       }
+      {set $dx_local_highway_guitar
+         {elem {find $entry highway_guitar} 1}
+      }
    }
    {if {== {elem $entry 0} {basename highway_bass}}
       {set $dx_highway_bass
+         {elem {find $entry highway_bass} 1}
+      }
+      {set $dx_local_highway_bass
          {elem {find $entry highway_bass} 1}
       }
    }
@@ -623,9 +629,15 @@
       {set $dx_highway_drum
          {elem {find $entry highway_drums} 1}
       }
+      {set $dx_local_highway_drum
+         {elem {find $entry highway_drums} 1}
+      }
    }
    {if {== {elem $entry 0} {basename highway_keys}}
       {set $dx_highway_keys
+         {elem {find $entry highway_keys} 1}
+      }
+      {set $dx_local_highway_keys
          {elem {find $entry highway_keys} 1}
       }
    }
@@ -653,9 +665,15 @@
       {set $dx_streak_guitar
          {elem {find $entry streak_guitar} 1}
       }
+      {set $dx_local_streak_guitar
+         {elem {find $entry streak_guitar} 1}
+      }
    }
    {if {== {elem $entry 0} {basename streak_bass}}
       {set $dx_streak_bass
+         {elem {find $entry streak_bass} 1}
+      }
+      {set $dx_local_streak_bass
          {elem {find $entry streak_bass} 1}
       }
    }
@@ -663,9 +681,15 @@
       {set $dx_streak_drum
          {elem {find $entry streak_drums} 1}
       }
+      {set $dx_local_streak_drum
+         {elem {find $entry streak_drums} 1}
+      }
    }
    {if {== {elem $entry 0} {basename streak_keys}}
       {set $dx_streak_keys
+         {elem {find $entry streak_keys} 1}
+      }
+      {set $dx_local_streak_keys
          {elem {find $entry streak_keys} 1}
       }
    }
@@ -673,9 +697,15 @@
       {set $dx_streak_prokeys
          {elem {find $entry streak_prokeys} 1}
       }
+      {set $dx_local_streak_prokeys
+         {elem {find $entry streak_prokeys} 1}
+      }
    }
    {if {== {elem $entry 0} {basename overdrive_guitar}}
       {set $dx_overdrive_guitar
+         {elem {find $entry overdrive_guitar} 1}
+      }
+      {set $dx_local_overdrive_guitar
          {elem {find $entry overdrive_guitar} 1}
       }
    }
@@ -683,9 +713,15 @@
       {set $dx_overdrive_bass
          {elem {find $entry overdrive_bass} 1}
       }
+      {set $dx_local_overdrive_bass
+         {elem {find $entry overdrive_bass} 1}
+      }
    }
    {if {== {elem $entry 0} {basename overdrive_drums}}
       {set $dx_overdrive_drum
+         {elem {find $entry overdrive_drums} 1}
+      }
+      {set $dx_local_overdrive_drum
          {elem {find $entry overdrive_drums} 1}
       }
    }
@@ -693,9 +729,15 @@
       {set $dx_overdrive_keys
          {elem {find $entry overdrive_keys} 1}
       }
+      {set $dx_local_overdrive_keys
+         {elem {find $entry overdrive_keys} 1}
+      }
    }
    {if {== {elem $entry 0} {basename overdrive_prokeys}}
       {set $dx_overdrive_prokeys
+         {elem {find $entry overdrive_prokeys} 1}
+      }
+      {set $dx_local_overdrive_prokeys
          {elem {find $entry overdrive_prokeys} 1}
       }
    }
@@ -814,9 +856,15 @@
       {set $dx_keyboard
          {elem {find $entry keyboard} 1}
       }
+      {set $dx_local_keyboard
+         {elem {find $entry keyboard} 1}
+      }
    }
    {if {== {elem $entry 0} {basename vocal_highway}}
       {set $dx_vocal_highway
+         {elem {find $entry vocal_highway} 1}
+      }
+      {set $dx_local_vocal_highway
          {elem {find $entry vocal_highway} 1}
       }
    }
@@ -824,14 +872,23 @@
       {set $dx_vocal_arrow
          {elem {find $entry vocal_arrows} 1}
       }
+      {set $dx_local_vocal_arrow
+         {elem {find $entry vocal_arrows} 1}
+      }
    }
    {if {== {elem $entry 0} {basename vocal_notes}}
       {set $dx_vocal_notes
          {elem {find $entry vocal_notes} 1}
       }
+      {set $dx_local_vocal_notes
+         {elem {find $entry vocal_notes} 1}
+      }
    }
    {if {== {elem $entry 0} {basename vocal_overdrive}}
       {set $dx_vocal_overdrive
+         {elem {find $entry vocal_overdrive} 1}
+      }
+      {set $dx_local_vocal_overdrive
          {elem {find $entry vocal_overdrive} 1}
       }
    }

--- a/_ark/dx/macros/dx_reader_macros.dta
+++ b/_ark/dx/macros/dx_reader_macros.dta
@@ -959,6 +959,7 @@
    {dx_modifier_reader mod_rb4lanes}
    {dx_modifier_reader mod_synced_track_speeds}
    {dx_modifier_reader mod_nopause}
+   {dx_modifier_reader mod_remote_texture_sync}
    {unless {modifier_mgr is_modifier_active mod_doublespeed}
       {dx_modifier_reader mod_doublespeed}
    }

--- a/_ark/dx/macros/dx_writer_macros.dta
+++ b/_ark/dx/macros/dx_writer_macros.dta
@@ -192,6 +192,10 @@
       {dx_setting_saver dx_modifiers mod_miss_sounds FALSE}
       {dx_setting_saver dx_modifiers mod_miss_sounds TRUE}
    }
+   {if_else {modifier_mgr is_modifier_active mod_remote_texture_sync}
+      {dx_setting_saver dx_modifiers mod_remote_texture_sync FALSE}
+      {dx_setting_saver dx_modifiers mod_remote_texture_sync TRUE}
+   }
    {dx_setting_saver dx_modifiers mod_practiceoverdrive {modifier_mgr is_modifier_active mod_practiceoverdrive}}
    {dx_setting_saver dx_modifiers mod_nolanes {modifier_mgr is_modifier_active mod_nolanes}}
    {dx_setting_saver dx_modifiers mod_rb4lanes {modifier_mgr is_modifier_active mod_rb4lanes}}

--- a/_ark/dx/overshell/dx_states.dta
+++ b/_ark/dx/overshell/dx_states.dta
@@ -40,6 +40,9 @@
       }
       {overshell_view_chooser}
    )
+   (enter
+      {dx_resync_local_textures all}
+   )
    (SCROLL_MSG
       DX_MENU_SCROLL_DESC ;updates description with currently selected modifier
    )

--- a/_ark/dx/overshell/dx_states.dta
+++ b/_ark/dx/overshell/dx_states.dta
@@ -41,6 +41,7 @@
       {overshell_view_chooser}
    )
    (enter
+      ;reapplies the user's own theme when entering dx settings to prevent remote textures from overriding their own theme
       {dx_resync_local_textures all}
    )
    (SCROLL_MSG

--- a/_ark/dx/overshell/dx_texture_states.dta
+++ b/_ark/dx/overshell/dx_texture_states.dta
@@ -372,23 +372,28 @@
          (keyboard_lanes
             {set $dx_keyboard_needs_reset TRUE}
             {set $dx_refresh_beatmatch TRUE}
-            {set $dx_keyboard {$component selected_sym}})
+            {set $dx_keyboard {$component selected_sym}}
+            {set $dx_local_keyboard {$component selected_sym}})
          (vocal_highway_bg
             {set $dx_vocal_highway_needs_reset TRUE}
             {set $dx_refresh_beatmatch TRUE}
-            {set $dx_vocal_highway {$component selected_sym}})
+            {set $dx_vocal_highway {$component selected_sym}}
+            {set $dx_local_vocal_highway {$component selected_sym}})
          (vocal_arrow
             {set $dx_vocal_arrow_needs_reset TRUE}
             {set $dx_refresh_beatmatch TRUE}
-            {set $dx_vocal_arrow {$component selected_sym}})
+            {set $dx_vocal_arrow {$component selected_sym}}
+            {set $dx_local_vocal_arrow {$component selected_sym}})
          (vocal_note_tube
             {set $dx_vocal_notes_needs_reset TRUE}
             {set $dx_refresh_beatmatch TRUE}
-            {set $dx_vocal_notes {$component selected_sym}})
+            {set $dx_vocal_notes {$component selected_sym}}
+            {set $dx_local_vocal_notes {$component selected_sym}})
          (vocal_overdrive_now_bar
             {set $dx_vocal_overdrive_needs_reset TRUE}
             {set $dx_refresh_beatmatch TRUE}
-            {set $dx_vocal_overdrive {$component selected_sym}})
+            {set $dx_vocal_overdrive {$component selected_sym}}
+            {set $dx_local_vocal_overdrive {$component selected_sym}})
       }
       {if_else
          {||
@@ -446,60 +451,60 @@
          (all_instruments
             {switch $dx_tracked_texture_loader
                 (overdrive
-                    {set $dx_overdrive_guitar_needs_reset TRUE} {set $dx_overdrive_guitar $dx_tracked_emissive}
-                    {set $dx_overdrive_bass_needs_reset TRUE} {set $dx_overdrive_bass $dx_tracked_emissive}
-                    {set $dx_overdrive_drum_needs_reset TRUE} {set $dx_overdrive_drum $dx_tracked_emissive}
-                    {set $dx_overdrive_keys_needs_reset TRUE} {set $dx_overdrive_keys $dx_tracked_emissive}
-                    {set $dx_overdrive_prokeys_needs_reset TRUE} {set $dx_overdrive_prokeys $dx_tracked_emissive}
+                    {set $dx_overdrive_guitar_needs_reset TRUE} {set $dx_overdrive_guitar $dx_tracked_emissive} {set $dx_local_overdrive_guitar $dx_tracked_emissive}
+                    {set $dx_overdrive_bass_needs_reset TRUE} {set $dx_overdrive_bass $dx_tracked_emissive} {set $dx_local_overdrive_bass $dx_tracked_emissive}
+                    {set $dx_overdrive_drum_needs_reset TRUE} {set $dx_overdrive_drum $dx_tracked_emissive} {set $dx_local_overdrive_drum $dx_tracked_emissive}
+                    {set $dx_overdrive_keys_needs_reset TRUE} {set $dx_overdrive_keys $dx_tracked_emissive} {set $dx_local_overdrive_keys $dx_tracked_emissive}
+                    {set $dx_overdrive_prokeys_needs_reset TRUE} {set $dx_overdrive_prokeys $dx_tracked_emissive} {set $dx_local_overdrive_prokeys $dx_tracked_emissive}
                 )
                 (highways
-                    {set $dx_highway_guitar_needs_reset TRUE} {set $dx_highway_guitar $dx_tracked_highway}
-                    {set $dx_highway_bass_needs_reset TRUE} {set $dx_highway_bass $dx_tracked_highway}
-                    {set $dx_highway_drum_needs_reset TRUE} {set $dx_highway_drum $dx_tracked_highway}
-                    {set $dx_highway_keys_needs_reset TRUE} {set $dx_highway_keys $dx_tracked_highway}
+                    {set $dx_highway_guitar_needs_reset TRUE} {set $dx_highway_guitar $dx_tracked_highway} {set $dx_local_highway_guitar $dx_tracked_highway}
+                    {set $dx_highway_bass_needs_reset TRUE} {set $dx_highway_bass $dx_tracked_highway} {set $dx_local_highway_bass $dx_tracked_highway}
+                    {set $dx_highway_drum_needs_reset TRUE} {set $dx_highway_drum $dx_tracked_highway} {set $dx_local_highway_drum $dx_tracked_highway}
+                    {set $dx_highway_keys_needs_reset TRUE} {set $dx_highway_keys $dx_tracked_highway} {set $dx_local_highway_keys $dx_tracked_highway}
                 )
                 (streaks
-                    {set $dx_streak_guitar_needs_reset TRUE} {set $dx_streak_guitar $dx_tracked_spotlight}
-                    {set $dx_streak_bass_needs_reset TRUE} {set $dx_streak_bass $dx_tracked_spotlight}
-                    {set $dx_streak_drum_needs_reset TRUE} {set $dx_streak_drum $dx_tracked_spotlight}
-                    {set $dx_streak_prokeys_needs_reset TRUE} {set $dx_streak_prokeys $dx_tracked_spotlight}
-                    {set $dx_streak_keys_needs_reset TRUE} {set $dx_streak_keys $dx_tracked_spotlight}
+                    {set $dx_streak_guitar_needs_reset TRUE} {set $dx_streak_guitar $dx_tracked_spotlight} {set $dx_local_streak_guitar $dx_tracked_spotlight}
+                    {set $dx_streak_bass_needs_reset TRUE} {set $dx_streak_bass $dx_tracked_spotlight} {set $dx_local_streak_bass $dx_tracked_spotlight}
+                    {set $dx_streak_drum_needs_reset TRUE} {set $dx_streak_drum $dx_tracked_spotlight} {set $dx_local_streak_drum $dx_tracked_spotlight}
+                    {set $dx_streak_prokeys_needs_reset TRUE} {set $dx_streak_prokeys $dx_tracked_spotlight} {set $dx_local_streak_prokeys $dx_tracked_spotlight}
+                    {set $dx_streak_keys_needs_reset TRUE} {set $dx_streak_keys $dx_tracked_spotlight} {set $dx_local_streak_keys $dx_tracked_spotlight}
                 )
             }
          )
          (guitar
             {switch $dx_tracked_texture_loader
-                (overdrive {set $dx_overdrive_guitar_needs_reset TRUE} {set $dx_overdrive_guitar $dx_tracked_emissive})
-                (highways {set $dx_highway_guitar_needs_reset TRUE} {set $dx_highway_guitar $dx_tracked_highway})
-                (streaks {set $dx_streak_guitar_needs_reset TRUE} {set $dx_streak_guitar $dx_tracked_spotlight})
+                (overdrive {set $dx_overdrive_guitar_needs_reset TRUE} {set $dx_overdrive_guitar $dx_tracked_emissive} {set $dx_local_overdrive_guitar $dx_tracked_emissive})
+                (highways {set $dx_highway_guitar_needs_reset TRUE} {set $dx_highway_guitar $dx_tracked_highway} {set $dx_local_highway_guitar $dx_tracked_highway})
+                (streaks {set $dx_streak_guitar_needs_reset TRUE} {set $dx_streak_guitar $dx_tracked_spotlight} {set $dx_local_streak_guitar $dx_tracked_spotlight})
             }
          )
          (bass
             {switch $dx_tracked_texture_loader
-                (overdrive {set $dx_overdrive_bass_needs_reset TRUE} {set $dx_overdrive_bass $dx_tracked_emissive})
-                (highways {set $dx_highway_bass_needs_reset TRUE} {set $dx_highway_bass $dx_tracked_highway})
-                (streaks {set $dx_streak_bass_needs_reset TRUE} {set $dx_streak_bass $dx_tracked_spotlight})
+                (overdrive {set $dx_overdrive_bass_needs_reset TRUE} {set $dx_overdrive_bass $dx_tracked_emissive} {set $dx_local_overdrive_bass $dx_tracked_emissive})
+                (highways {set $dx_highway_bass_needs_reset TRUE} {set $dx_highway_bass $dx_tracked_highway} {set $dx_local_highway_bass $dx_tracked_highway})
+                (streaks {set $dx_streak_bass_needs_reset TRUE} {set $dx_streak_bass $dx_tracked_spotlight} {set $dx_local_streak_bass $dx_tracked_spotlight})
             }
          )
          (drums
             {switch $dx_tracked_texture_loader
-                (overdrive {set $dx_overdrive_drum_needs_reset TRUE} {set $dx_overdrive_drum $dx_tracked_emissive})
-                (highways {set $dx_highway_drum_needs_reset TRUE} {set $dx_highway_drum $dx_tracked_highway})
-                (streaks {set $dx_streak_drum_needs_reset TRUE} {set $dx_streak_drum $dx_tracked_spotlight})
+                (overdrive {set $dx_overdrive_drum_needs_reset TRUE} {set $dx_overdrive_drum $dx_tracked_emissive} {set $dx_local_overdrive_drum $dx_tracked_emissive})
+                (highways {set $dx_highway_drum_needs_reset TRUE} {set $dx_highway_drum $dx_tracked_highway} {set $dx_local_highway_drum $dx_tracked_highway})
+                (streaks {set $dx_streak_drum_needs_reset TRUE} {set $dx_streak_drum $dx_tracked_spotlight} {set $dx_local_streak_drum $dx_tracked_spotlight})
             }
          )
          (keys
             {switch $dx_tracked_texture_loader
-                (overdrive {set $dx_overdrive_keys_needs_reset TRUE} {set $dx_overdrive_keys $dx_tracked_emissive})
-                (highways {set $dx_highway_keys_needs_reset TRUE} {set $dx_highway_keys $dx_tracked_highway})
-                (streaks {set $dx_streak_keys_needs_reset TRUE} {set $dx_streak_keys $dx_tracked_spotlight})
+                (overdrive {set $dx_overdrive_keys_needs_reset TRUE} {set $dx_overdrive_keys $dx_tracked_emissive} {set $dx_local_overdrive_keys $dx_tracked_emissive})
+                (highways {set $dx_highway_keys_needs_reset TRUE} {set $dx_highway_keys $dx_tracked_highway} {set $dx_local_highway_keys $dx_tracked_highway})
+                (streaks {set $dx_streak_keys_needs_reset TRUE} {set $dx_streak_keys $dx_tracked_spotlight} {set $dx_local_streak_keys $dx_tracked_spotlight})
             }
          )
          (pro_keys
             {switch $dx_tracked_texture_loader
-                (overdrive {set $dx_overdrive_prokeys_needs_reset TRUE} {set $dx_overdrive_prokeys $dx_tracked_emissive})
-                (highways {set $dx_highway_prokeys_needs_reset TRUE} {set $dx_highway_prokeys $dx_tracked_highway})
-                (streaks {set $dx_streak_prokeys_needs_reset TRUE} {set $dx_streak_prokeys $dx_tracked_spotlight})
+                (overdrive {set $dx_overdrive_prokeys_needs_reset TRUE} {set $dx_overdrive_prokeys $dx_tracked_emissive} {set $dx_local_overdrive_prokeys $dx_tracked_emissive})
+                (highways {set $dx_highway_prokeys_needs_reset TRUE} {set $dx_highway_prokeys $dx_tracked_highway} {set $dx_local_highway_prokeys $dx_tracked_highway})
+                (streaks {set $dx_streak_prokeys_needs_reset TRUE} {set $dx_streak_prokeys $dx_tracked_spotlight} {set $dx_local_streak_prokeys $dx_tracked_spotlight})
             }
          )
       }

--- a/_ark/dx/track/dx_track_funcs.dta
+++ b/_ark/dx/track/dx_track_funcs.dta
@@ -663,273 +663,439 @@
       }
    }
 }
-
+(func
+   dx_resync_local_textures
+   ($instrument)
+   {switch
+      (guitar
+         {unless {== $dx_highway_guitar $dx_local_highway_guitar}
+            {set $dx_highway_guitar $dx_local_highway_guitar}
+            {set $dx_highway_guitar_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_guitar $dx_local_streak_guitar}
+            {set $dx_streak_guitar $dx_local_streak_guitar}
+            {set $dx_streak_guitar_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_guitar $dx_local_overdrive_guitar}
+            {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
+            {set $dx_overdrive_guitar_needs_reset TRUE}
+         }
+      )
+      (bass
+         {unless {== $dx_highway_bass $dx_local_highway_bass}
+            {set $dx_highway_bass $dx_local_highway_bass}
+            {set $dx_highway_bass_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_bass $dx_local_streak_bass}
+            {set $dx_streak_bass $dx_local_streak_bass}
+            {set $dx_streak_bass_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
+            {set $dx_overdrive_bass $dx_local_overdrive_bass}
+            {set $dx_overdrive_bass_needs_reset TRUE}
+         }
+      )
+      (drums
+         {unless {== $dx_highway_drum $dx_local_highway_drum}
+            {set $dx_highway_drum $dx_local_highway_drum}
+            {set $dx_highway_drum_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_drum $dx_local_streak_drum}
+            {set $dx_streak_drum $dx_local_streak_drum}
+            {set $dx_streak_drum_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
+            {set $dx_overdrive_drum $dx_local_overdrive_drum}
+            {set $dx_overdrive_drum_needs_reset TRUE}
+         }
+      )
+      (keys
+         {unless {== $dx_highway_keys $dx_local_highway_keys}
+            {set $dx_highway_keys $dx_local_highway_keys}
+            {set $dx_highway_keys_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_keys $dx_local_streak_keys}
+            {set $dx_streak_keys $dx_local_streak_keys}
+            {set $dx_streak_keys_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
+            {set $dx_overdrive_keys $dx_local_overdrive_keys}
+            {set $dx_overdrive_keys_needs_reset TRUE}
+         }
+      )
+      (real_keys
+         {unless {== $dx_keyboard $dx_local_keyboard}
+            {set $dx_keyboard $dx_local_keyboard}
+            {set $dx_keyboard_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
+            {set $dx_streak_prokeys $dx_local_streak_prokeys}
+            {set $dx_streak_prokeys_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+            {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+            {set $dx_overdrive_prokeys_needs_reset TRUE}
+         }
+      )
+      (vocals
+         {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
+            {set $vocal_arrow $dx_local_vocal_arrowd}
+            {set $dx_vocal_arrow_needs_reset TRUE}
+         }
+         {unless {== $dx_vocal_highway $dx_local_vocal_highway}
+            {set $dx_vocal_highway $dx_local_vocal_highway}
+            {set $dx_vocal_highway_needs_reset TRUE}
+         }
+         {unless {== $dx_vocal_notes $dx_local_vocal_notes}
+            {set $dx_vocal_notes $dx_local_vocal_notes}
+            {set $dx_vocal_notes_needs_reset TRUE}
+         }
+         {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
+            {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
+            {set $dx_vocal_overdrive_needs_reset TRUE}
+         }
+      )
+      (all
+         {unless {== $dx_highway_guitar $dx_local_highway_guitar}
+            {set $dx_highway_guitar $dx_local_highway_guitar}
+            {set $dx_highway_guitar_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_guitar $dx_local_streak_guitar}
+            {set $dx_streak_guitar $dx_local_streak_guitar}
+            {set $dx_streak_guitar_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_guitar $dx_local_overdrive_guitar}
+            {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
+            {set $dx_overdrive_guitar_needs_reset TRUE}
+         }
+         {unless {== $dx_highway_bass $dx_local_highway_bass}
+            {set $dx_highway_bass $dx_local_highway_bass}
+            {set $dx_highway_bass_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_bass $dx_local_streak_bass}
+            {set $dx_streak_bass $dx_local_streak_bass}
+            {set $dx_streak_bass_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
+            {set $dx_overdrive_bass $dx_local_overdrive_bass}
+            {set $dx_overdrive_bass_needs_reset TRUE}
+         }
+         {unless {== $dx_highway_drum $dx_local_highway_drum}
+            {set $dx_highway_drum $dx_local_highway_drum}
+            {set $dx_highway_drum_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_drum $dx_local_streak_drum}
+            {set $dx_streak_drum $dx_local_streak_drum}
+            {set $dx_streak_drum_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
+            {set $dx_overdrive_drum $dx_local_overdrive_drum}
+            {set $dx_overdrive_drum_needs_reset TRUE}
+         }
+         {unless {== $dx_highway_keys $dx_local_highway_keys}
+            {set $dx_highway_keys $dx_local_highway_keys}
+            {set $dx_highway_keys_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_keys $dx_local_streak_keys}
+            {set $dx_streak_keys $dx_local_streak_keys}
+            {set $dx_streak_keys_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
+            {set $dx_overdrive_keys $dx_local_overdrive_keys}
+            {set $dx_overdrive_keys_needs_reset TRUE}
+         }
+         {unless {== $dx_keyboard $dx_local_keyboard}
+            {set $dx_keyboard $dx_local_keyboard}
+            {set $dx_keyboard_needs_reset TRUE}
+         }
+         {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
+            {set $dx_streak_prokeys $dx_local_streak_prokeys}
+            {set $dx_streak_prokeys_needs_reset TRUE}
+         }
+         {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+            {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+            {set $dx_overdrive_prokeys_needs_reset TRUE}
+         }
+         {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
+            {set $vocal_arrow $dx_local_vocal_arrowd}
+            {set $dx_vocal_arrow_needs_reset TRUE}
+         }
+         {unless {== $dx_vocal_highway $dx_local_vocal_highway}
+            {set $dx_vocal_highway $dx_local_vocal_highway}
+            {set $dx_vocal_highway_needs_reset TRUE}
+         }
+         {unless {== $dx_vocal_notes $dx_local_vocal_notes}
+            {set $dx_vocal_notes $dx_local_vocal_notes}
+            {set $dx_vocal_notes_needs_reset TRUE}
+         }
+         {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
+            {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
+            {set $dx_vocal_overdrive_needs_reset TRUE}
+         }
+      )
+   }
+)
 (func
    dx_sync_remote_textures
    ($instrument)
-   {if {modifier_mgr is_modifier_active mod_remote_texture_sync}
-      {switch $instrument
-         (guitar
-            {unless {== $dx_highway_guitar $dx_local_highway_guitar}
-               {set $dx_highway_guitar $dx_local_highway_guitar}
-               {set $dx_highway_guitar_needs_reset TRUE}
-            }
-            {unless {== $dx_streak_guitar $dx_local_streak_guitar}
-               {set $dx_streak_guitar $dx_local_streak_guitar}
-               {set $dx_streak_guitar_needs_reset TRUE}
-            }
-            {unless {== $dx_overdrive_guitar $dx_local_overdrive_guitar}
-               {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
-               {set $dx_overdrive_guitar_needs_reset TRUE}
-            }
-            {session send_msg_to_all
-               {'`' 
-                  (
-                     {if $dx_remote_highway_guitar ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                           {do
-                              {set $dx_remote_highway_guitar {',' $dx_local_highway_guitar}}
-                              {unless {== $dx_remote_highway_guitar $dx_highway_guitar}
-                                 {set $dx_highway_guitar $dx_remote_highway_guitar}
-                                 {set $dx_highway_guitar_needs_reset TRUE}
-                              }
-                              {set $dx_remote_streak_guitar {',' $dx_local_streak_guitar}}
-                              {unless {== $dx_remote_streak_guitar $dx_streak_guitar}
-                                 {set $dx_streak_guitar $dx_remote_streak_guitar}
-                                 {set $dx_streak_guitar_needs_reset TRUE}
-                              }
-                              {set $dx_remote_overdrive_guitar {',' $dx_local_overdrive_guitar}}
-                              {unless {== $dx_remote_overdrive_guitar $dx_overdrive_guitar}
-                                 {set $dx_overdrive_guitar $dx_remote_overdrive_guitar}
-                                 {set $dx_overdrive_guitar_needs_reset TRUE}
+   {if_else {session_mgr is_local}
+      {dx_resync_local_textures all}
+      {if_else {modifier_mgr is_modifier_active mod_remote_texture_sync}
+         {do
+            {dx_resync_local_textures $instrument}
+            {switch $instrument
+               (guitar
+                  {session send_msg_to_all
+                     {'`' 
+                        (
+                           {if $dx_remote_highway_guitar ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                 {do
+                                    {set $dx_remote_highway_guitar {',' $dx_local_highway_guitar}}
+                                    {unless {== $dx_remote_highway_guitar $dx_highway_guitar}
+                                       {set $dx_highway_guitar $dx_remote_highway_guitar}
+                                       {set $dx_highway_guitar_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_streak_guitar {',' $dx_local_streak_guitar}}
+                                    {unless {== $dx_remote_streak_guitar $dx_streak_guitar}
+                                       {set $dx_streak_guitar $dx_remote_streak_guitar}
+                                       {set $dx_streak_guitar_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_overdrive_guitar {',' $dx_local_overdrive_guitar}}
+                                    {unless {== $dx_remote_overdrive_guitar $dx_overdrive_guitar}
+                                       {set $dx_overdrive_guitar $dx_remote_overdrive_guitar}
+                                       {set $dx_overdrive_guitar_needs_reset TRUE}
+                                    }
+                                 }
                               }
                            }
-                        }
+                        )
+                        kNetReliable
                      }
-                  )
-                  kNetReliable
-               }
-            }
-         )
-         (bass
-            {unless {== $dx_highway_bass $dx_local_highway_bass}
-               {set $dx_highway_bass $dx_local_highway_bass}
-               {set $dx_highway_bass_needs_reset TRUE}
-            }
-            {unless {== $dx_streak_bass $dx_local_streak_bass}
-               {set $dx_streak_bass $dx_local_streak_bass}
-               {set $dx_streak_bass_needs_reset TRUE}
-            }
-            {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
-               {set $dx_overdrive_bass $dx_local_overdrive_bass}
-               {set $dx_overdrive_bass_needs_reset TRUE}
-            }
-            {session send_msg_to_all
-               {'`' 
-                  (
-                     {if $dx_remote_highway_bass ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                           {do
-                              {set $dx_remote_highway_bass {',' $dx_local_highway_bass}}
-                              {unless {== $dx_remote_highway_bass $dx_highway_bass}
-                                 {set $dx_highway_bass $dx_remote_highway_bass}
-                                 {set $dx_highway_bass_needs_reset TRUE}
-                              }
-                              {set $dx_remote_streak_bass {',' $dx_local_streak_bass}}
-                              {unless {== $dx_remote_streak_bass $dx_streak_bass}
-                                 {set $dx_streak_bass $dx_remote_streak_bass}
-                                 {set $dx_streak_bass_needs_reset TRUE}
-                              }
-                              {set $dx_remote_overdrive_bass {',' $dx_local_overdrive_bass}}
-                              {unless {== $dx_remote_overdrive_bass $dx_overdrive_bass}
-                                 {set $dx_overdrive_bass $dx_remote_overdrive_bass}
-                                 {set $dx_overdrive_bass_needs_reset TRUE}
+                  }
+               )
+               (bass
+                  {unless {== $dx_highway_bass $dx_local_highway_bass}
+                     {set $dx_highway_bass $dx_local_highway_bass}
+                     {set $dx_highway_bass_needs_reset TRUE}
+                  }
+                  {unless {== $dx_streak_bass $dx_local_streak_bass}
+                     {set $dx_streak_bass $dx_local_streak_bass}
+                     {set $dx_streak_bass_needs_reset TRUE}
+                  }
+                  {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
+                     {set $dx_overdrive_bass $dx_local_overdrive_bass}
+                     {set $dx_overdrive_bass_needs_reset TRUE}
+                  }
+                  {session send_msg_to_all
+                     {'`' 
+                        (
+                           {if $dx_remote_highway_bass ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                 {do
+                                    {set $dx_remote_highway_bass {',' $dx_local_highway_bass}}
+                                    {unless {== $dx_remote_highway_bass $dx_highway_bass}
+                                       {set $dx_highway_bass $dx_remote_highway_bass}
+                                       {set $dx_highway_bass_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_streak_bass {',' $dx_local_streak_bass}}
+                                    {unless {== $dx_remote_streak_bass $dx_streak_bass}
+                                       {set $dx_streak_bass $dx_remote_streak_bass}
+                                       {set $dx_streak_bass_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_overdrive_bass {',' $dx_local_overdrive_bass}}
+                                    {unless {== $dx_remote_overdrive_bass $dx_overdrive_bass}
+                                       {set $dx_overdrive_bass $dx_remote_overdrive_bass}
+                                       {set $dx_overdrive_bass_needs_reset TRUE}
+                                    }
+                                 }
                               }
                            }
-                        }
+                        )
+                        kNetReliable
                      }
-                  )
-                  kNetReliable
-               }
-            }
-         )
-         (drums
-            {unless {== $dx_highway_drum $dx_local_highway_drum}
-               {set $dx_highway_drum $dx_local_highway_drum}
-               {set $dx_highway_drum_needs_reset TRUE}
-            }
-            {unless {== $dx_streak_drum $dx_local_streak_drum}
-               {set $dx_streak_drum $dx_local_streak_drum}
-               {set $dx_streak_drum_needs_reset TRUE}
-            }
-            {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
-               {set $dx_overdrive_drum $dx_local_overdrive_drum}
-               {set $dx_overdrive_drum_needs_reset TRUE}
-            }
-            {session send_msg_to_all
-               {'`' 
-                  (
-                     {if $dx_remote_highway_drum ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                           {do
-                              {set $dx_remote_highway_drum {',' $dx_local_highway_drum}}
-                              {unless {== $dx_remote_highway_drum $dx_highway_drum}
-                                 {set $dx_highway_drum $dx_remote_highway_drum}
-                                 {set $dx_highway_drum_needs_reset TRUE}
-                              }
-                              {set $dx_remote_streak_drum {',' $dx_local_streak_drum}}
-                              {unless {== $dx_remote_streak_drum $dx_streak_drum}
-                                 {set $dx_streak_drum $dx_remote_streak_drum}
-                                 {set $dx_streak_drum_needs_reset TRUE}
-                              }
-                              {set $dx_remote_overdrive_drum {',' $dx_local_overdrive_drum}}
-                              {unless {== $dx_remote_overdrive_drum $dx_overdrive_drum}
-                                 {set $dx_overdrive_drum $dx_remote_overdrive_drum}
-                                 {set $dx_overdrive_drum_needs_reset TRUE}
+                  }
+               )
+               (drums
+                  {unless {== $dx_highway_drum $dx_local_highway_drum}
+                     {set $dx_highway_drum $dx_local_highway_drum}
+                     {set $dx_highway_drum_needs_reset TRUE}
+                  }
+                  {unless {== $dx_streak_drum $dx_local_streak_drum}
+                     {set $dx_streak_drum $dx_local_streak_drum}
+                     {set $dx_streak_drum_needs_reset TRUE}
+                  }
+                  {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
+                     {set $dx_overdrive_drum $dx_local_overdrive_drum}
+                     {set $dx_overdrive_drum_needs_reset TRUE}
+                  }
+                  {session send_msg_to_all
+                     {'`' 
+                        (
+                           {if $dx_remote_highway_drum ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                 {do
+                                    {set $dx_remote_highway_drum {',' $dx_local_highway_drum}}
+                                    {unless {== $dx_remote_highway_drum $dx_highway_drum}
+                                       {set $dx_highway_drum $dx_remote_highway_drum}
+                                       {set $dx_highway_drum_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_streak_drum {',' $dx_local_streak_drum}}
+                                    {unless {== $dx_remote_streak_drum $dx_streak_drum}
+                                       {set $dx_streak_drum $dx_remote_streak_drum}
+                                       {set $dx_streak_drum_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_overdrive_drum {',' $dx_local_overdrive_drum}}
+                                    {unless {== $dx_remote_overdrive_drum $dx_overdrive_drum}
+                                       {set $dx_overdrive_drum $dx_remote_overdrive_drum}
+                                       {set $dx_overdrive_drum_needs_reset TRUE}
+                                    }
+                                 }
                               }
                            }
-                        }
+                        )
+                        kNetReliable
                      }
-                  )
-                  kNetReliable
-               }
-            }
-         )
-         (keys
-            {unless {== $dx_highway_keys $dx_local_highway_keys}
-               {set $dx_highway_keys $dx_local_highway_keys}
-               {set $dx_highway_keys_needs_reset TRUE}
-            }
-            {unless {== $dx_streak_keys $dx_local_streak_keys}
-               {set $dx_streak_keys $dx_local_streak_keys}
-               {set $dx_streak_keys_needs_reset TRUE}
-            }
-            {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
-               {set $dx_overdrive_keys $dx_local_overdrive_keys}
-               {set $dx_overdrive_keys_needs_reset TRUE}
-            }
-            {session send_msg_to_all
-               {'`' 
-                  (
-                     {if $dx_remote_highway_keys ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                           {do
-                              {set $dx_remote_highway_keys {',' $dx_local_highway_keys}}
-                              {unless {== $dx_remote_highway_keys $dx_highway_keys}
-                                 {set $dx_highway_keys $dx_remote_highway_keys}
-                                 {set $dx_highway_keys_needs_reset TRUE}
-                              }
-                              {set $dx_remote_streak_keys {',' $dx_local_streak_keys}}
-                              {unless {== $dx_remote_streak_keys $dx_streak_keys}
-                                 {set $dx_streak_keys $dx_remote_streak_keys}
-                                 {set $dx_streak_keys_needs_reset TRUE}
-                              }
-                              {set $dx_remote_overdrive_keys {',' $dx_local_overdrive_keys}}
-                              {unless {== $dx_remote_overdrive_keys $dx_overdrive_keys}
-                                 {set $dx_overdrive_keys $dx_remote_overdrive_keys}
-                                 {set $dx_overdrive_keys_needs_reset TRUE}
+                  }
+               )
+               (keys
+                  {unless {== $dx_highway_keys $dx_local_highway_keys}
+                     {set $dx_highway_keys $dx_local_highway_keys}
+                     {set $dx_highway_keys_needs_reset TRUE}
+                  }
+                  {unless {== $dx_streak_keys $dx_local_streak_keys}
+                     {set $dx_streak_keys $dx_local_streak_keys}
+                     {set $dx_streak_keys_needs_reset TRUE}
+                  }
+                  {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
+                     {set $dx_overdrive_keys $dx_local_overdrive_keys}
+                     {set $dx_overdrive_keys_needs_reset TRUE}
+                  }
+                  {session send_msg_to_all
+                     {'`' 
+                        (
+                           {if $dx_remote_highway_keys ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                 {do
+                                    {set $dx_remote_highway_keys {',' $dx_local_highway_keys}}
+                                    {unless {== $dx_remote_highway_keys $dx_highway_keys}
+                                       {set $dx_highway_keys $dx_remote_highway_keys}
+                                       {set $dx_highway_keys_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_streak_keys {',' $dx_local_streak_keys}}
+                                    {unless {== $dx_remote_streak_keys $dx_streak_keys}
+                                       {set $dx_streak_keys $dx_remote_streak_keys}
+                                       {set $dx_streak_keys_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_overdrive_keys {',' $dx_local_overdrive_keys}}
+                                    {unless {== $dx_remote_overdrive_keys $dx_overdrive_keys}
+                                       {set $dx_overdrive_keys $dx_remote_overdrive_keys}
+                                       {set $dx_overdrive_keys_needs_reset TRUE}
+                                    }
+                                 }
                               }
                            }
-                        }
+                        )
+                        kNetReliable
                      }
-                  )
-                  kNetReliable
-               }
-            }
-         )
-         (real_keys
-            {unless {== $dx_keyboard $dx_local_keyboard}
-               {set $dx_keyboard $dx_local_keyboard}
-               {set $dx_keyboard_needs_reset TRUE}
-            }
-            {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
-               {set $dx_streak_prokeys $dx_local_streak_prokeys}
-               {set $dx_streak_prokeys_needs_reset TRUE}
-            }
-            {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
-               {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
-               {set $dx_overdrive_prokeys_needs_reset TRUE}
-            }
-            {session send_msg_to_all
-               {'`' 
-                  (
-                     {if $dx_remote_keyboard ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                           {do
-                              {set $dx_remote_keyboard {',' $dx_local_keyboard}}
-                              {unless {== $dx_remote_keyboard $dx_keyboard}
-                                 {set $dx_keyboard $dx_remote_keyboard}
-                                 {set $dx_keyboard_needs_reset TRUE}
-                              }
-                              {set $dx_remote_streak_prokeys {',' $dx_local_streak_prokeys}}
-                              {unless {== $dx_remote_streak_prokeys $dx_streak_prokeys}
-                                 {set $dx_streak_prokeys $dx_remote_streak_prokeys}
-                                 {set $dx_streak_prokeys_needs_reset TRUE}
-                              }
-                              {set $dx_remote_overdrive_prokeys {',' $dx_local_overdrive_prokeys}}
-                              {unless {== $dx_remote_overdrive_prokeys $dx_overdrive_prokeys}
-                                 {set $dx_overdrive_prokeys $dx_remote_overdrive_prokeys}
-                                 {set $dx_overdrive_prokeys_needs_reset TRUE}
+                  }
+               )
+               (real_keys
+                  {unless {== $dx_keyboard $dx_local_keyboard}
+                     {set $dx_keyboard $dx_local_keyboard}
+                     {set $dx_keyboard_needs_reset TRUE}
+                  }
+                  {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
+                     {set $dx_streak_prokeys $dx_local_streak_prokeys}
+                     {set $dx_streak_prokeys_needs_reset TRUE}
+                  }
+                  {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+                     {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+                     {set $dx_overdrive_prokeys_needs_reset TRUE}
+                  }
+                  {session send_msg_to_all
+                     {'`' 
+                        (
+                           {if $dx_remote_keyboard ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                 {do
+                                    {set $dx_remote_keyboard {',' $dx_local_keyboard}}
+                                    {unless {== $dx_remote_keyboard $dx_keyboard}
+                                       {set $dx_keyboard $dx_remote_keyboard}
+                                       {set $dx_keyboard_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_streak_prokeys {',' $dx_local_streak_prokeys}}
+                                    {unless {== $dx_remote_streak_prokeys $dx_streak_prokeys}
+                                       {set $dx_streak_prokeys $dx_remote_streak_prokeys}
+                                       {set $dx_streak_prokeys_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_overdrive_prokeys {',' $dx_local_overdrive_prokeys}}
+                                    {unless {== $dx_remote_overdrive_prokeys $dx_overdrive_prokeys}
+                                       {set $dx_overdrive_prokeys $dx_remote_overdrive_prokeys}
+                                       {set $dx_overdrive_prokeys_needs_reset TRUE}
+                                    }
+                                 }
                               }
                            }
-                        }
+                        )
+                        kNetReliable
                      }
-                  )
-                  kNetReliable
-               }
-            }
-         )
-         (vocals
-            {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
-               {set $vocal_arrow $dx_local_vocal_arrowd}
-               {set $dx_vocal_arrow_needs_reset TRUE}
-            }
-            {unless {== $dx_vocal_highway $dx_local_vocal_highway}
-               {set $dx_vocal_highway $dx_local_vocal_highway}
-               {set $dx_vocal_highway_needs_reset TRUE}
-            }
-            {unless {== $dx_vocal_notes $dx_local_vocal_notes}
-               {set $dx_vocal_notes $dx_local_vocal_notes}
-               {set $dx_vocal_notes_needs_reset TRUE}
-            }
-            {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
-               {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
-               {set $dx_vocal_overdrive_needs_reset TRUE}
-            }
-            {session send_msg_to_all
-               {'`' 
-                  (
-                     {if $dx_vocal_highway ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                           {do
-                              {set $dx_remote_vocal_arrow {',' $dx_local_vocal_arrow}}
-                              {unless {== $dx_remote_vocal_arrow $dx_vocal_arrow}
-                                 {set $dx_vocal_arrow $dx_remote_vocal_arrow}
-                                 {set $dx_vocal_arrow_needs_reset TRUE}
-                              }
-                              {set $dx_remote_vocal_highway {',' $dx_local_vocal_highway}}
-                              {unless {== $dx_remote_vocal_highway $dx_vocal_highway}
-                                 {set $dx_vocal_highway $dx_remote_vocal_highway}
-                                 {set $dx_vocal_highway_needs_reset TRUE}
-                              }
-                              {set $dx_remote_vocal_notes {',' $dx_local_vocal_notes}}
-                              {unless {== $dx_remote_vocal_notes $dx_vocal_notes}
-                                 {set $dx_vocal_notes $dx_remote_vocal_notes}
-                                 {set $dx_vocal_notes_needs_reset TRUE}
-                              }
-                              {set $dx_remote_vocal_overdrive {',' $dx_local_vocal_overdrive}}
-                              {unless {== $dx_remote_vocal_overdrive $dx_vocal_overdrive}
-                                 {set $dx_vocal_overdrive $dx_remote_vocal_overdrive}
-                                 {set $dx_vocal_overdrive_needs_reset TRUE}
+                  }
+               )
+               (vocals
+                  {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
+                     {set $vocal_arrow $dx_local_vocal_arrowd}
+                     {set $dx_vocal_arrow_needs_reset TRUE}
+                  }
+                  {unless {== $dx_vocal_highway $dx_local_vocal_highway}
+                     {set $dx_vocal_highway $dx_local_vocal_highway}
+                     {set $dx_vocal_highway_needs_reset TRUE}
+                  }
+                  {unless {== $dx_vocal_notes $dx_local_vocal_notes}
+                     {set $dx_vocal_notes $dx_local_vocal_notes}
+                     {set $dx_vocal_notes_needs_reset TRUE}
+                  }
+                  {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
+                     {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
+                     {set $dx_vocal_overdrive_needs_reset TRUE}
+                  }
+                  {session send_msg_to_all
+                     {'`' 
+                        (
+                           {if $dx_vocal_highway ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                 {do
+                                    {set $dx_remote_vocal_arrow {',' $dx_local_vocal_arrow}}
+                                    {unless {== $dx_remote_vocal_arrow $dx_vocal_arrow}
+                                       {set $dx_vocal_arrow $dx_remote_vocal_arrow}
+                                       {set $dx_vocal_arrow_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_vocal_highway {',' $dx_local_vocal_highway}}
+                                    {unless {== $dx_remote_vocal_highway $dx_vocal_highway}
+                                       {set $dx_vocal_highway $dx_remote_vocal_highway}
+                                       {set $dx_vocal_highway_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_vocal_notes {',' $dx_local_vocal_notes}}
+                                    {unless {== $dx_remote_vocal_notes $dx_vocal_notes}
+                                       {set $dx_vocal_notes $dx_remote_vocal_notes}
+                                       {set $dx_vocal_notes_needs_reset TRUE}
+                                    }
+                                    {set $dx_remote_vocal_overdrive {',' $dx_local_vocal_overdrive}}
+                                    {unless {== $dx_remote_vocal_overdrive $dx_vocal_overdrive}
+                                       {set $dx_vocal_overdrive $dx_remote_vocal_overdrive}
+                                       {set $dx_vocal_overdrive_needs_reset TRUE}
+                                    }
+                                 }
                               }
                            }
-                        }
+                        )
+                        kNetReliable
                      }
-                  )
-                  kNetReliable
-               }
+                  }
+               )
             }
-         )
+         }
+         {dx_resync_local_textures all}
       }
    }
 )

--- a/_ark/dx/track/dx_track_funcs.dta
+++ b/_ark/dx/track/dx_track_funcs.dta
@@ -667,10 +667,10 @@
    dx_resync_local_textures
    ($instrument)
    {do
-      {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures"}}
+      {dx_log_writer info {sprint "dx_resync_local_textures"}}
       {switch $instrument
-         (guitar
-            {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures: GUITAR RAN"}}
+         ((kTrackGuitar kTrackRealGuitar)
+            {dx_log_writer info {sprint "dx_resync_local_textures: resetting guitar texture to local setting"}}
             {unless {== $dx_highway_guitar $dx_local_highway_guitar}
                {set $dx_highway_guitar $dx_local_highway_guitar}
                {set $dx_highway_guitar_needs_reset TRUE}
@@ -683,9 +683,9 @@
                {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
                {set $dx_overdrive_guitar_needs_reset TRUE}
             }
-            {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures: END OF GUITAR RAN"}}
          )
-         (bass
+         ((kTrackBass kTrackRealBass)
+            {dx_log_writer info {sprint "dx_resync_local_textures: resetting bass texture to local setting"}}
             {unless {== $dx_highway_bass $dx_local_highway_bass}
                {set $dx_highway_bass $dx_local_highway_bass}
                {set $dx_highway_bass_needs_reset TRUE}
@@ -699,7 +699,8 @@
                {set $dx_overdrive_bass_needs_reset TRUE}
             }
          )
-         (drums
+         (kTrackDrum
+            {dx_log_writer info {sprint "dx_resync_local_textures: resetting drum texture to local setting"}}
             {unless {== $dx_highway_drum $dx_local_highway_drum}
                {set $dx_highway_drum $dx_local_highway_drum}
                {set $dx_highway_drum_needs_reset TRUE}
@@ -713,7 +714,8 @@
                {set $dx_overdrive_drum_needs_reset TRUE}
             }
          )
-         (keys
+         (kTrackKeys
+            {dx_log_writer info {sprint "dx_resync_local_textures: resetting keys texture to local setting"}}
             {unless {== $dx_highway_keys $dx_local_highway_keys}
                {set $dx_highway_keys $dx_local_highway_keys}
                {set $dx_highway_keys_needs_reset TRUE}
@@ -727,7 +729,8 @@
                {set $dx_overdrive_keys_needs_reset TRUE}
             }
          )
-         (real_keys
+         (kTrackRealKeys
+            {dx_log_writer info {sprint "dx_resync_local_textures: resetting real_keys texture to local setting"}}
             {unless {== $dx_keyboard $dx_local_keyboard}
                {set $dx_keyboard $dx_local_keyboard}
                {set $dx_keyboard_needs_reset TRUE}
@@ -741,7 +744,8 @@
                {set $dx_overdrive_prokeys_needs_reset TRUE}
             }
          )
-         (vocals
+         (kTrackVocals
+            {dx_log_writer info {sprint "dx_resync_local_textures: resetting vocals texture to local setting"}}
             {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
                {set $vocal_arrow $dx_local_vocal_arrowd}
                {set $dx_vocal_arrow_needs_reset TRUE}
@@ -760,7 +764,7 @@
             }
          )
          (all
-            {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures: ALL RAN"}}
+            {dx_log_writer info {sprint "dx_resync_local_textures: resetting every texture to local setting"}}
             {unless {== $dx_highway_guitar $dx_local_highway_guitar}
                {set $dx_highway_guitar $dx_local_highway_guitar}
                {set $dx_highway_guitar_needs_reset TRUE}
@@ -837,56 +841,165 @@
                {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
                {set $dx_vocal_overdrive_needs_reset TRUE}
             }
-            {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures: END OF ALL RAN"}}
          )
       }
+   }
+)
+(func
+   dx_apply_remote_textures
+   {if_else {modifier_mgr is_modifier_active mod_remote_texture_sync}
+      {do
+         {user_mgr
+            foreach_user
+            $user
+            {switch {$user get_track_type}
+               ((kTrackGuitar kTrackRealGuitar)
+                  {if_else {$user is_local}
+                     {dx_resync_local_textures kTrackGuitar}
+                     {do
+                        {unless {== $dx_remote_highway_guitar $dx_highway_guitar}
+                           {set $dx_highway_guitar $dx_remote_highway_guitar}
+                           {set $dx_highway_guitar_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_streak_guitar $dx_streak_guitar}
+                           {set $dx_streak_guitar $dx_remote_streak_guitar}
+                           {set $dx_streak_guitar_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_overdrive_guitar $dx_overdrive_guitar}
+                           {set $dx_overdrive_guitar $dx_remote_overdrive_guitar}
+                           {set $dx_overdrive_guitar_needs_reset TRUE}
+                        }
+                     }
+                  }
+               )
+               ((kTrackBass kTrackRealBass)
+                  {if_else {$user is_local}
+                     {dx_resync_local_textures kTrackBass}
+                     {do
+                        {unless {== $dx_remote_highway_bass $dx_highway_bass}
+                           {set $dx_highway_bass $dx_remote_highway_bass}
+                           {set $dx_highway_bass_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_streak_bass $dx_streak_bass}
+                           {set $dx_streak_bass $dx_remote_streak_bass}
+                           {set $dx_streak_bass_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_overdrive_bass $dx_overdrive_bass}
+                           {set $dx_overdrive_bass $dx_remote_overdrive_bass}
+                           {set $dx_overdrive_bass_needs_reset TRUE}
+                        }
+                     }
+                  }
+               )
+               (kTrackDrum
+                  {if_else {$user is_local}
+                     {dx_resync_local_textures kTrackDrum}
+                     {do
+                        {unless {== $dx_remote_highway_drum $dx_highway_drum}
+                           {set $dx_highway_drum $dx_remote_highway_drum}
+                           {set $dx_highway_drum_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_streak_drum $dx_streak_drum}
+                           {set $dx_streak_drum $dx_remote_streak_drum}
+                           {set $dx_streak_drum_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_overdrive_drum $dx_overdrive_drum}
+                           {set $dx_overdrive_drum $dx_remote_overdrive_drum}
+                           {set $dx_overdrive_drum_needs_reset TRUE}
+                        }
+                     }
+                  }
+               )
+               (kTrackKeys
+                  {if_else {$user is_local}
+                     {dx_resync_local_textures kTrackKeys}
+                     {do
+                        {unless {== $dx_remote_highway_keys $dx_highway_keys}
+                           {set $dx_highway_keys $dx_remote_highway_keys}
+                           {set $dx_highway_keys_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_streak_keys $dx_streak_keys}
+                           {set $dx_streak_keys $dx_remote_streak_keys}
+                           {set $dx_streak_keys_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_overdrive_keys $dx_overdrive_keys}
+                           {set $dx_overdrive_keys $dx_remote_overdrive_keys}
+                           {set $dx_overdrive_keys_needs_reset TRUE}
+                        }
+                     }
+                  }
+               )
+               (kTrackRealKeys
+                  {if_else {$user is_local}
+                     {dx_resync_local_textures kTrackRealKeys}
+                     {do
+                        {unless {== $dx_remote_keyboard $dx_keyboard}
+                           {set $dx_keyboard $dx_remote_keyboard}
+                           {set $dx_keyboard_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_streak_prokeys $dx_streak_prokeys}
+                           {set $dx_streak_prokeys $dx_remote_streak_prokeys}
+                           {set $dx_streak_prokeys_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_overdrive_prokeys $dx_overdrive_prokeys}
+                           {set $dx_overdrive_prokeys $dx_remote_overdrive_prokeys}
+                           {set $dx_overdrive_prokeys_needs_reset TRUE}
+                        }
+                     }
+                  }
+               )
+               (kTrackVocals
+                  {if_else {$user is_local}
+                     {dx_resync_local_textures kTrackRealKeys}
+                     {do
+                        {unless {== $dx_remote_vocal_arrow $dx_vocal_arrow}
+                           {set $dx_vocal_arrow $dx_remote_vocal_arrow}
+                           {set $dx_vocal_arrow_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_vocal_highway $dx_vocal_highway}
+                           {set $dx_vocal_highway $dx_remote_vocal_highway}
+                           {set $dx_vocal_highway_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_vocal_notes $dx_vocal_notes}
+                           {set $dx_vocal_notes $dx_remote_vocal_notes}
+                           {set $dx_vocal_notes_needs_reset TRUE}
+                        }
+                        {unless {== $dx_remote_vocal_overdrive $dx_vocal_overdrive}
+                           {set $dx_vocal_overdrive $dx_remote_vocal_overdrive}
+                           {set $dx_vocal_overdrive_needs_reset TRUE}
+                        }
+                     }
+                  }
+               )
+            }
+         }
+      }
+      {dx_resync_local_textures all}
    }
 )
 (func
    dx_sync_remote_textures
    ($instrument)
    {do
-      {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures"}}
+      {dx_log_writer info {sprint "dx_sync_remote_textures"}}
       {if_else {session_mgr is_local}
          {dx_resync_local_textures all}
          {if_else {modifier_mgr is_modifier_active mod_remote_texture_sync}
             {do
-               {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: PREPPING TO SEND TEXTURES"}}
+               {dx_log_writer info {sprint "dx_sync_remote_textures: PREPPING TO SEND TEXTURES"}}
                {dx_resync_local_textures $instrument}
                {switch $instrument
-                  (guitar
+                  ((kTrackGuitar kTrackRealGuitar)
                      {do
-                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING GUITAR MESSAGE"}}
+                        {dx_log_writer info {sprint "dx_sync_remote_textures: SENDING GUITAR MESSAGE"}}
                         {session send_msg_to_all
                            {'`' 
                               (
                                  {do
-                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS GUITAR REMOTE_HIGHWAY CHECK"}}
-                                    {if $dx_remote_highway_guitar ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                                       {do
-                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE GUITAR HIGHWAY PASSED"}}
-                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                             {do
-                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT GUITAR TEXTURES"}}
-                                                {set $dx_remote_highway_guitar {',' $dx_local_highway_guitar}}
-                                                {unless {== $dx_remote_highway_guitar $dx_highway_guitar}
-                                                   {set $dx_highway_guitar $dx_remote_highway_guitar}
-                                                   {set $dx_highway_guitar_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_streak_guitar {',' $dx_local_streak_guitar}}
-                                                {unless {== $dx_remote_streak_guitar $dx_streak_guitar}
-                                                   {set $dx_streak_guitar $dx_remote_streak_guitar}
-                                                   {set $dx_streak_guitar_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_overdrive_guitar {',' $dx_local_overdrive_guitar}}
-                                                {unless {== $dx_remote_overdrive_guitar $dx_overdrive_guitar}
-                                                   {set $dx_overdrive_guitar $dx_remote_overdrive_guitar}
-                                                   {set $dx_overdrive_guitar_needs_reset TRUE}
-                                                }
-                                             }
-                                          }
-                                       }
-                                    }
+                                    {dx_log_writer info {sprint "dx_sync_remote_textures: RECEIVED GUITAR TEXTURES"}}
+                                    {set $dx_remote_highway_guitar {',' $dx_local_highway_guitar}}
+                                    {set $dx_remote_streak_guitar {',' $dx_local_streak_guitar}}
+                                    {set $dx_remote_overdrive_guitar {',' $dx_local_overdrive_guitar}}
                                  }
                               )
                               kNetReliable
@@ -894,39 +1007,17 @@
                         }
                      }
                   )
-                  (bass
+                  ((kTrackBass kTrackRealBass)
                      {do
-                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING bass MESSAGE"}}
+                        {dx_log_writer info {sprint "dx_sync_remote_textures: SENDING bass MESSAGE"}}
                         {session send_msg_to_all
                            {'`' 
                               (
                                  {do
-                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS bass REMOTE_HIGHWAY CHECK"}}
-                                    {if $dx_remote_highway_bass ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                                       {do
-                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE bass HIGHWAY PASSED"}}
-                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                             {do
-                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT bass TEXTURES"}}
-                                                {set $dx_remote_highway_bass {',' $dx_local_highway_bass}}
-                                                {unless {== $dx_remote_highway_bass $dx_highway_bass}
-                                                   {set $dx_highway_bass $dx_remote_highway_bass}
-                                                   {set $dx_highway_bass_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_streak_bass {',' $dx_local_streak_bass}}
-                                                {unless {== $dx_remote_streak_bass $dx_streak_bass}
-                                                   {set $dx_streak_bass $dx_remote_streak_bass}
-                                                   {set $dx_streak_bass_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_overdrive_bass {',' $dx_local_overdrive_bass}}
-                                                {unless {== $dx_remote_overdrive_bass $dx_overdrive_bass}
-                                                   {set $dx_overdrive_bass $dx_remote_overdrive_bass}
-                                                   {set $dx_overdrive_bass_needs_reset TRUE}
-                                                }
-                                             }
-                                          }
-                                       }
-                                    }
+                                    {dx_log_writer info {sprint "dx_sync_remote_textures: RECEIVED bass TEXTURES"}}
+                                    {set $dx_remote_highway_bass {',' $dx_local_highway_bass}}
+                                    {set $dx_remote_streak_bass {',' $dx_local_streak_bass}}
+                                    {set $dx_remote_overdrive_bass {',' $dx_local_overdrive_bass}}
                                  }
                               )
                               kNetReliable
@@ -934,39 +1025,17 @@
                         }
                      }
                   )
-                  (drums
+                  (kTrackDrum
                      {do
-                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING drum MESSAGE"}}
+                        {dx_log_writer info {sprint "dx_sync_remote_textures: SENDING drum MESSAGE"}}
                         {session send_msg_to_all
                            {'`' 
                               (
                                  {do
-                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS drum REMOTE_HIGHWAY CHECK"}}
-                                    {if $dx_remote_highway_drum ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                                       {do
-                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE drum HIGHWAY PASSED"}}
-                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                             {do
-                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT drum TEXTURES"}}
-                                                {set $dx_remote_highway_drum {',' $dx_local_highway_drum}}
-                                                {unless {== $dx_remote_highway_drum $dx_highway_drum}
-                                                   {set $dx_highway_drum $dx_remote_highway_drum}
-                                                   {set $dx_highway_drum_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_streak_drum {',' $dx_local_streak_drum}}
-                                                {unless {== $dx_remote_streak_drum $dx_streak_drum}
-                                                   {set $dx_streak_drum $dx_remote_streak_drum}
-                                                   {set $dx_streak_drum_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_overdrive_drum {',' $dx_local_overdrive_drum}}
-                                                {unless {== $dx_remote_overdrive_drum $dx_overdrive_drum}
-                                                   {set $dx_overdrive_drum $dx_remote_overdrive_drum}
-                                                   {set $dx_overdrive_drum_needs_reset TRUE}
-                                                }
-                                             }
-                                          }
-                                       }
-                                    }
+                                    {dx_log_writer info {sprint "dx_sync_remote_textures: RECEIVED drum TEXTURES"}}
+                                    {set $dx_remote_highway_drum {',' $dx_local_highway_drum}}
+                                    {set $dx_remote_streak_drum {',' $dx_local_streak_drum}}
+                                    {set $dx_remote_overdrive_drum {',' $dx_local_overdrive_drum}}
                                  }
                               )
                               kNetReliable
@@ -974,39 +1043,17 @@
                         }
                      }
                   )
-                  (keys
+                  (kTrackKeys
                      {do
-                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING keys MESSAGE"}}
+                        {dx_log_writer info {sprint "dx_sync_remote_textures: SENDING keys MESSAGE"}}
                         {session send_msg_to_all
                            {'`' 
                               (
                                  {do
-                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS keys REMOTE_HIGHWAY CHECK"}}
-                                    {if $dx_remote_highway_keys ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                                       {do
-                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE keys HIGHWAY PASSED"}}
-                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                             {do
-                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT keys TEXTURES"}}
-                                                {set $dx_remote_highway_keys {',' $dx_local_highway_keys}}
-                                                {unless {== $dx_remote_highway_keys $dx_highway_keys}
-                                                   {set $dx_highway_keys $dx_remote_highway_keys}
-                                                   {set $dx_highway_keys_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_streak_keys {',' $dx_local_streak_keys}}
-                                                {unless {== $dx_remote_streak_keys $dx_streak_keys}
-                                                   {set $dx_streak_keys $dx_remote_streak_keys}
-                                                   {set $dx_streak_keys_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_overdrive_keys {',' $dx_local_overdrive_keys}}
-                                                {unless {== $dx_remote_overdrive_keys $dx_overdrive_keys}
-                                                   {set $dx_overdrive_keys $dx_remote_overdrive_keys}
-                                                   {set $dx_overdrive_keys_needs_reset TRUE}
-                                                }
-                                             }
-                                          }
-                                       }
-                                    }
+                                    {dx_log_writer info {sprint "dx_sync_remote_textures: RECEIVED keys TEXTURES"}}
+                                    {set $dx_remote_highway_keys {',' $dx_local_highway_keys}}
+                                    {set $dx_remote_streak_keys {',' $dx_local_streak_keys}}
+                                    {set $dx_remote_overdrive_keys {',' $dx_local_overdrive_keys}}
                                  }
                               )
                               kNetReliable
@@ -1014,39 +1061,17 @@
                         }
                      }
                   )
-                  (real_keys
+                  (kTrackRealKeys
                      {do
-                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING prokeys MESSAGE"}}
+                        {dx_log_writer info {sprint "dx_sync_remote_textures: SENDING prokeys MESSAGE"}}
                         {session send_msg_to_all
                            {'`' 
                               (
                                  {do
-                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS prokeys REMOTE_HIGHWAY CHECK"}}
-                                    {if $dx_remote_keyboard ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                                       {do
-                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE prokeys HIGHWAY PASSED"}}
-                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                             {do
-                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT prokeys TEXTURES"}}
-                                                {set $dx_remote_keyboard {',' $dx_local_keyboard}}
-                                                {unless {== $dx_remote_keyboard $dx_keyboard}
-                                                   {set $dx_keyboard $dx_remote_keyboard}
-                                                   {set $dx_keyboard_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_streak_prokeys {',' $dx_local_streak_prokeys}}
-                                                {unless {== $dx_remote_streak_prokeys $dx_streak_prokeys}
-                                                   {set $dx_streak_prokeys $dx_remote_streak_prokeys}
-                                                   {set $dx_streak_prokeys_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_overdrive_prokeys {',' $dx_local_overdrive_prokeys}}
-                                                {unless {== $dx_remote_overdrive_prokeys $dx_overdrive_prokeys}
-                                                   {set $dx_overdrive_prokeys $dx_remote_overdrive_prokeys}
-                                                   {set $dx_overdrive_prokeys_needs_reset TRUE}
-                                                }
-                                             }
-                                          }
-                                       }
-                                    }
+                                    {dx_log_writer info {sprint "dx_sync_remote_textures: RECEIVED prokeys TEXTURES"}}
+                                    {set $dx_remote_keyboard {',' $dx_local_keyboard}}
+                                    {set $dx_remote_streak_prokeys {',' $dx_local_streak_prokeys}}
+                                    {set $dx_remote_overdrive_prokeys {',' $dx_local_overdrive_prokeys}}
                                  }
                               )
                               kNetReliable
@@ -1054,43 +1079,18 @@
                         }
                      }
                   )
-                  (vocals
+                  (kTrackVocals
                      {do
-                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING vocals MESSAGE"}}
+                        {dx_log_writer info {sprint "dx_sync_remote_textures: SENDING vocals MESSAGE"}}
                         {session send_msg_to_all
                            {'`' 
                               (
                                  {do
-                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS vocals REMOTE_HIGHWAY CHECK"}}
-                                    {if $dx_vocal_highway ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                                       {do
-                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE vocals HIGHWAY PASSED"}}
-                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                             {do
-                                                {set $dx_remote_vocal_arrow {',' $dx_local_vocal_arrow}}
-                                                {unless {== $dx_remote_vocal_arrow $dx_vocal_arrow}
-                                                   {set $dx_vocal_arrow $dx_remote_vocal_arrow}
-                                                   {set $dx_vocal_arrow_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_vocal_highway {',' $dx_local_vocal_highway}}
-                                                {unless {== $dx_remote_vocal_highway $dx_vocal_highway}
-                                                   {set $dx_vocal_highway $dx_remote_vocal_highway}
-                                                   {set $dx_vocal_highway_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_vocal_notes {',' $dx_local_vocal_notes}}
-                                                {unless {== $dx_remote_vocal_notes $dx_vocal_notes}
-                                                   {set $dx_vocal_notes $dx_remote_vocal_notes}
-                                                   {set $dx_vocal_notes_needs_reset TRUE}
-                                                }
-                                                {set $dx_remote_vocal_overdrive {',' $dx_local_vocal_overdrive}}
-                                                {unless {== $dx_remote_vocal_overdrive $dx_vocal_overdrive}
-                                                   {set $dx_vocal_overdrive $dx_remote_vocal_overdrive}
-                                                   {set $dx_vocal_overdrive_needs_reset TRUE}
-                                                }
-                                             }
-                                          }
-                                       }
-                                    }
+                                    {dx_log_writer info {sprint "dx_sync_remote_textures: RECEIVED vocals TEXTURES"}}
+                                    {set $dx_remote_vocal_arrow {',' $dx_local_vocal_arrow}}
+                                    {set $dx_remote_vocal_highway {',' $dx_local_vocal_highway}}
+                                    {set $dx_remote_vocal_notes {',' $dx_local_vocal_notes}}
+                                    {set $dx_remote_vocal_overdrive {',' $dx_local_vocal_overdrive}}
                                  }
                               )
                               kNetReliable

--- a/_ark/dx/track/dx_track_funcs.dta
+++ b/_ark/dx/track/dx_track_funcs.dta
@@ -663,3 +663,273 @@
       }
    }
 }
+
+(func
+   dx_sync_remote_textures
+   ($instrument)
+   {if {modifier_mgr is_modifier_active mod_remote_texture_sync}
+      {switch $instrument
+         (guitar
+            {unless {== $dx_highway_guitar $dx_local_highway_guitar}
+               {set $dx_highway_guitar $dx_local_highway_guitar}
+               {set $dx_highway_guitar_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_guitar $dx_local_streak_guitar}
+               {set $dx_streak_guitar $dx_local_streak_guitar}
+               {set $dx_streak_guitar_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_guitar $dx_local_overdrive_guitar}
+               {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
+               {set $dx_overdrive_guitar_needs_reset TRUE}
+            }
+            {session send_msg_to_all
+               {'`' 
+                  (
+                     {if $dx_remote_highway_guitar ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                           {do
+                              {set $dx_remote_highway_guitar {',' $dx_local_highway_guitar}}
+                              {unless {== $dx_remote_highway_guitar $dx_highway_guitar}
+                                 {set $dx_highway_guitar $dx_remote_highway_guitar}
+                                 {set $dx_highway_guitar_needs_reset TRUE}
+                              }
+                              {set $dx_remote_streak_guitar {',' $dx_local_streak_guitar}}
+                              {unless {== $dx_remote_streak_guitar $dx_streak_guitar}
+                                 {set $dx_streak_guitar $dx_remote_streak_guitar}
+                                 {set $dx_streak_guitar_needs_reset TRUE}
+                              }
+                              {set $dx_remote_overdrive_guitar {',' $dx_local_overdrive_guitar}}
+                              {unless {== $dx_remote_overdrive_guitar $dx_overdrive_guitar}
+                                 {set $dx_overdrive_guitar $dx_remote_overdrive_guitar}
+                                 {set $dx_overdrive_guitar_needs_reset TRUE}
+                              }
+                           }
+                        }
+                     }
+                  )
+                  kNetReliable
+               }
+            }
+         )
+         (bass
+            {unless {== $dx_highway_bass $dx_local_highway_bass}
+               {set $dx_highway_bass $dx_local_highway_bass}
+               {set $dx_highway_bass_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_bass $dx_local_streak_bass}
+               {set $dx_streak_bass $dx_local_streak_bass}
+               {set $dx_streak_bass_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
+               {set $dx_overdrive_bass $dx_local_overdrive_bass}
+               {set $dx_overdrive_bass_needs_reset TRUE}
+            }
+            {session send_msg_to_all
+               {'`' 
+                  (
+                     {if $dx_remote_highway_bass ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                           {do
+                              {set $dx_remote_highway_bass {',' $dx_local_highway_bass}}
+                              {unless {== $dx_remote_highway_bass $dx_highway_bass}
+                                 {set $dx_highway_bass $dx_remote_highway_bass}
+                                 {set $dx_highway_bass_needs_reset TRUE}
+                              }
+                              {set $dx_remote_streak_bass {',' $dx_local_streak_bass}}
+                              {unless {== $dx_remote_streak_bass $dx_streak_bass}
+                                 {set $dx_streak_bass $dx_remote_streak_bass}
+                                 {set $dx_streak_bass_needs_reset TRUE}
+                              }
+                              {set $dx_remote_overdrive_bass {',' $dx_local_overdrive_bass}}
+                              {unless {== $dx_remote_overdrive_bass $dx_overdrive_bass}
+                                 {set $dx_overdrive_bass $dx_remote_overdrive_bass}
+                                 {set $dx_overdrive_bass_needs_reset TRUE}
+                              }
+                           }
+                        }
+                     }
+                  )
+                  kNetReliable
+               }
+            }
+         )
+         (drums
+            {unless {== $dx_highway_drum $dx_local_highway_drum}
+               {set $dx_highway_drum $dx_local_highway_drum}
+               {set $dx_highway_drum_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_drum $dx_local_streak_drum}
+               {set $dx_streak_drum $dx_local_streak_drum}
+               {set $dx_streak_drum_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
+               {set $dx_overdrive_drum $dx_local_overdrive_drum}
+               {set $dx_overdrive_drum_needs_reset TRUE}
+            }
+            {session send_msg_to_all
+               {'`' 
+                  (
+                     {if $dx_remote_highway_drum ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                           {do
+                              {set $dx_remote_highway_drum {',' $dx_local_highway_drum}}
+                              {unless {== $dx_remote_highway_drum $dx_highway_drum}
+                                 {set $dx_highway_drum $dx_remote_highway_drum}
+                                 {set $dx_highway_drum_needs_reset TRUE}
+                              }
+                              {set $dx_remote_streak_drum {',' $dx_local_streak_drum}}
+                              {unless {== $dx_remote_streak_drum $dx_streak_drum}
+                                 {set $dx_streak_drum $dx_remote_streak_drum}
+                                 {set $dx_streak_drum_needs_reset TRUE}
+                              }
+                              {set $dx_remote_overdrive_drum {',' $dx_local_overdrive_drum}}
+                              {unless {== $dx_remote_overdrive_drum $dx_overdrive_drum}
+                                 {set $dx_overdrive_drum $dx_remote_overdrive_drum}
+                                 {set $dx_overdrive_drum_needs_reset TRUE}
+                              }
+                           }
+                        }
+                     }
+                  )
+                  kNetReliable
+               }
+            }
+         )
+         (keys
+            {unless {== $dx_highway_keys $dx_local_highway_keys}
+               {set $dx_highway_keys $dx_local_highway_keys}
+               {set $dx_highway_keys_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_keys $dx_local_streak_keys}
+               {set $dx_streak_keys $dx_local_streak_keys}
+               {set $dx_streak_keys_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
+               {set $dx_overdrive_keys $dx_local_overdrive_keys}
+               {set $dx_overdrive_keys_needs_reset TRUE}
+            }
+            {session send_msg_to_all
+               {'`' 
+                  (
+                     {if $dx_remote_highway_keys ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                           {do
+                              {set $dx_remote_highway_keys {',' $dx_local_highway_keys}}
+                              {unless {== $dx_remote_highway_keys $dx_highway_keys}
+                                 {set $dx_highway_keys $dx_remote_highway_keys}
+                                 {set $dx_highway_keys_needs_reset TRUE}
+                              }
+                              {set $dx_remote_streak_keys {',' $dx_local_streak_keys}}
+                              {unless {== $dx_remote_streak_keys $dx_streak_keys}
+                                 {set $dx_streak_keys $dx_remote_streak_keys}
+                                 {set $dx_streak_keys_needs_reset TRUE}
+                              }
+                              {set $dx_remote_overdrive_keys {',' $dx_local_overdrive_keys}}
+                              {unless {== $dx_remote_overdrive_keys $dx_overdrive_keys}
+                                 {set $dx_overdrive_keys $dx_remote_overdrive_keys}
+                                 {set $dx_overdrive_keys_needs_reset TRUE}
+                              }
+                           }
+                        }
+                     }
+                  )
+                  kNetReliable
+               }
+            }
+         )
+         (real_keys
+            {unless {== $dx_keyboard $dx_local_keyboard}
+               {set $dx_keyboard $dx_local_keyboard}
+               {set $dx_keyboard_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
+               {set $dx_streak_prokeys $dx_local_streak_prokeys}
+               {set $dx_streak_prokeys_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+               {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+               {set $dx_overdrive_prokeys_needs_reset TRUE}
+            }
+            {session send_msg_to_all
+               {'`' 
+                  (
+                     {if $dx_remote_keyboard ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                           {do
+                              {set $dx_remote_keyboard {',' $dx_local_keyboard}}
+                              {unless {== $dx_remote_keyboard $dx_keyboard}
+                                 {set $dx_keyboard $dx_remote_keyboard}
+                                 {set $dx_keyboard_needs_reset TRUE}
+                              }
+                              {set $dx_remote_streak_prokeys {',' $dx_local_streak_prokeys}}
+                              {unless {== $dx_remote_streak_prokeys $dx_streak_prokeys}
+                                 {set $dx_streak_prokeys $dx_remote_streak_prokeys}
+                                 {set $dx_streak_prokeys_needs_reset TRUE}
+                              }
+                              {set $dx_remote_overdrive_prokeys {',' $dx_local_overdrive_prokeys}}
+                              {unless {== $dx_remote_overdrive_prokeys $dx_overdrive_prokeys}
+                                 {set $dx_overdrive_prokeys $dx_remote_overdrive_prokeys}
+                                 {set $dx_overdrive_prokeys_needs_reset TRUE}
+                              }
+                           }
+                        }
+                     }
+                  )
+                  kNetReliable
+               }
+            }
+         )
+         (vocals
+            {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
+               {set $vocal_arrow $dx_local_vocal_arrowd}
+               {set $dx_vocal_arrow_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_highway $dx_local_vocal_highway}
+               {set $dx_vocal_highway $dx_local_vocal_highway}
+               {set $dx_vocal_highway_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_notes $dx_local_vocal_notes}
+               {set $dx_vocal_notes $dx_local_vocal_notes}
+               {set $dx_vocal_notes_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
+               {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
+               {set $dx_vocal_overdrive_needs_reset TRUE}
+            }
+            {session send_msg_to_all
+               {'`' 
+                  (
+                     {if $dx_vocal_highway ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                        {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                           {do
+                              {set $dx_remote_vocal_arrow {',' $dx_local_vocal_arrow}}
+                              {unless {== $dx_remote_vocal_arrow $dx_vocal_arrow}
+                                 {set $dx_vocal_arrow $dx_remote_vocal_arrow}
+                                 {set $dx_vocal_arrow_needs_reset TRUE}
+                              }
+                              {set $dx_remote_vocal_highway {',' $dx_local_vocal_highway}}
+                              {unless {== $dx_remote_vocal_highway $dx_vocal_highway}
+                                 {set $dx_vocal_highway $dx_remote_vocal_highway}
+                                 {set $dx_vocal_highway_needs_reset TRUE}
+                              }
+                              {set $dx_remote_vocal_notes {',' $dx_local_vocal_notes}}
+                              {unless {== $dx_remote_vocal_notes $dx_vocal_notes}
+                                 {set $dx_vocal_notes $dx_remote_vocal_notes}
+                                 {set $dx_vocal_notes_needs_reset TRUE}
+                              }
+                              {set $dx_remote_vocal_overdrive {',' $dx_local_vocal_overdrive}}
+                              {unless {== $dx_remote_vocal_overdrive $dx_vocal_overdrive}
+                                 {set $dx_vocal_overdrive $dx_remote_vocal_overdrive}
+                                 {set $dx_vocal_overdrive_needs_reset TRUE}
+                              }
+                           }
+                        }
+                     }
+                  )
+                  kNetReliable
+               }
+            }
+         )
+      }
+   }
+)

--- a/_ark/dx/track/dx_track_funcs.dta
+++ b/_ark/dx/track/dx_track_funcs.dta
@@ -663,6 +663,7 @@
       }
    }
 }
+; this function will re-apply the local player's texture setting if it was previously changed by a remote player 
 (func
    dx_resync_local_textures
    ($instrument)
@@ -763,6 +764,7 @@
                {set $dx_vocal_overdrive_needs_reset TRUE}
             }
          )
+         ; checks every instrument texture if playing offline or if modifier was disabled
          (all
             {dx_log_writer info {sprint "dx_resync_local_textures: resetting every texture to local setting"}}
             {unless {== $dx_highway_guitar $dx_local_highway_guitar}
@@ -855,7 +857,9 @@
             {switch {$user get_track_type}
                ((kTrackGuitar kTrackRealGuitar)
                   {if_else {$user is_local}
+                     ; if the local player is on guitar, run function to (re)apply their own theme if needed
                      {dx_resync_local_textures kTrackGuitar}
+                     ; otherwise apply a new guitar texture if one was received from a remote player
                      {do
                         {unless {== $dx_remote_highway_guitar $dx_highway_guitar}
                            {set $dx_highway_guitar $dx_remote_highway_guitar}
@@ -874,7 +878,9 @@
                )
                ((kTrackBass kTrackRealBass)
                   {if_else {$user is_local}
+                     ; if the local player is on bass, run function to (re)apply their own theme if needed
                      {dx_resync_local_textures kTrackBass}
+                     ; otherwise apply a new bass texture if one was received from a remote player
                      {do
                         {unless {== $dx_remote_highway_bass $dx_highway_bass}
                            {set $dx_highway_bass $dx_remote_highway_bass}
@@ -893,7 +899,9 @@
                )
                (kTrackDrum
                   {if_else {$user is_local}
+                     ; if the local player is on drums, run function to (re)apply their own theme if needed
                      {dx_resync_local_textures kTrackDrum}
+                     ; otherwise apply a new drum texture if one was received from a remote player
                      {do
                         {unless {== $dx_remote_highway_drum $dx_highway_drum}
                            {set $dx_highway_drum $dx_remote_highway_drum}
@@ -912,7 +920,9 @@
                )
                (kTrackKeys
                   {if_else {$user is_local}
+                     ; if the local player is on keys, run function to (re)apply their own theme if needed
                      {dx_resync_local_textures kTrackKeys}
+                     ; otherwise apply a new keys texture if one was received from a remote player
                      {do
                         {unless {== $dx_remote_highway_keys $dx_highway_keys}
                            {set $dx_highway_keys $dx_remote_highway_keys}
@@ -931,7 +941,9 @@
                )
                (kTrackRealKeys
                   {if_else {$user is_local}
+                     ; if the local player is on pro keys, run function to (re)apply their own theme if needed
                      {dx_resync_local_textures kTrackRealKeys}
+                     ; otherwise apply a new pro keys texture if one was received from a remote player
                      {do
                         {unless {== $dx_remote_keyboard $dx_keyboard}
                            {set $dx_keyboard $dx_remote_keyboard}
@@ -950,7 +962,9 @@
                )
                (kTrackVocals
                   {if_else {$user is_local}
+                     ; if the local player is on vocals, run function to (re)apply their own theme if needed
                      {dx_resync_local_textures kTrackRealKeys}
+                     ; otherwise apply a new vocals texture if one was received from a remote player
                      {do
                         {unless {== $dx_remote_vocal_arrow $dx_vocal_arrow}
                            {set $dx_vocal_arrow $dx_remote_vocal_arrow}
@@ -977,17 +991,18 @@
       {dx_resync_local_textures all}
    }
 )
+; function to tell remote players what texture(s) the local player has
 (func
    dx_sync_remote_textures
    ($instrument)
    {do
       {dx_log_writer info {sprint "dx_sync_remote_textures"}}
       {if_else {session_mgr is_local}
-         {dx_resync_local_textures all}
+         {dx_resync_local_textures all} ; automatically use local user's own theme if playing offline
          {if_else {modifier_mgr is_modifier_active mod_remote_texture_sync}
             {do
                {dx_log_writer info {sprint "dx_sync_remote_textures: PREPPING TO SEND TEXTURES"}}
-               {dx_resync_local_textures $instrument}
+               {dx_resync_local_textures $instrument} ; makes sure the local user is using their own theme on their instrument
                {switch $instrument
                   ((kTrackGuitar kTrackRealGuitar)
                      {do
@@ -1100,7 +1115,7 @@
                   )
                }
             }
-            {dx_resync_local_textures all}
+            {dx_resync_local_textures all} ; automatically use local user's own theme if modifier is off
          }
       }
    }

--- a/_ark/dx/track/dx_track_funcs.dta
+++ b/_ark/dx/track/dx_track_funcs.dta
@@ -666,436 +666,442 @@
 (func
    dx_resync_local_textures
    ($instrument)
-   {switch
-      (guitar
-         {unless {== $dx_highway_guitar $dx_local_highway_guitar}
-            {set $dx_highway_guitar $dx_local_highway_guitar}
-            {set $dx_highway_guitar_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_guitar $dx_local_streak_guitar}
-            {set $dx_streak_guitar $dx_local_streak_guitar}
-            {set $dx_streak_guitar_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_guitar $dx_local_overdrive_guitar}
-            {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
-            {set $dx_overdrive_guitar_needs_reset TRUE}
-         }
-      )
-      (bass
-         {unless {== $dx_highway_bass $dx_local_highway_bass}
-            {set $dx_highway_bass $dx_local_highway_bass}
-            {set $dx_highway_bass_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_bass $dx_local_streak_bass}
-            {set $dx_streak_bass $dx_local_streak_bass}
-            {set $dx_streak_bass_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
-            {set $dx_overdrive_bass $dx_local_overdrive_bass}
-            {set $dx_overdrive_bass_needs_reset TRUE}
-         }
-      )
-      (drums
-         {unless {== $dx_highway_drum $dx_local_highway_drum}
-            {set $dx_highway_drum $dx_local_highway_drum}
-            {set $dx_highway_drum_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_drum $dx_local_streak_drum}
-            {set $dx_streak_drum $dx_local_streak_drum}
-            {set $dx_streak_drum_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
-            {set $dx_overdrive_drum $dx_local_overdrive_drum}
-            {set $dx_overdrive_drum_needs_reset TRUE}
-         }
-      )
-      (keys
-         {unless {== $dx_highway_keys $dx_local_highway_keys}
-            {set $dx_highway_keys $dx_local_highway_keys}
-            {set $dx_highway_keys_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_keys $dx_local_streak_keys}
-            {set $dx_streak_keys $dx_local_streak_keys}
-            {set $dx_streak_keys_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
-            {set $dx_overdrive_keys $dx_local_overdrive_keys}
-            {set $dx_overdrive_keys_needs_reset TRUE}
-         }
-      )
-      (real_keys
-         {unless {== $dx_keyboard $dx_local_keyboard}
-            {set $dx_keyboard $dx_local_keyboard}
-            {set $dx_keyboard_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
-            {set $dx_streak_prokeys $dx_local_streak_prokeys}
-            {set $dx_streak_prokeys_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
-            {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
-            {set $dx_overdrive_prokeys_needs_reset TRUE}
-         }
-      )
-      (vocals
-         {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
-            {set $vocal_arrow $dx_local_vocal_arrowd}
-            {set $dx_vocal_arrow_needs_reset TRUE}
-         }
-         {unless {== $dx_vocal_highway $dx_local_vocal_highway}
-            {set $dx_vocal_highway $dx_local_vocal_highway}
-            {set $dx_vocal_highway_needs_reset TRUE}
-         }
-         {unless {== $dx_vocal_notes $dx_local_vocal_notes}
-            {set $dx_vocal_notes $dx_local_vocal_notes}
-            {set $dx_vocal_notes_needs_reset TRUE}
-         }
-         {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
-            {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
-            {set $dx_vocal_overdrive_needs_reset TRUE}
-         }
-      )
-      (all
-         {unless {== $dx_highway_guitar $dx_local_highway_guitar}
-            {set $dx_highway_guitar $dx_local_highway_guitar}
-            {set $dx_highway_guitar_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_guitar $dx_local_streak_guitar}
-            {set $dx_streak_guitar $dx_local_streak_guitar}
-            {set $dx_streak_guitar_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_guitar $dx_local_overdrive_guitar}
-            {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
-            {set $dx_overdrive_guitar_needs_reset TRUE}
-         }
-         {unless {== $dx_highway_bass $dx_local_highway_bass}
-            {set $dx_highway_bass $dx_local_highway_bass}
-            {set $dx_highway_bass_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_bass $dx_local_streak_bass}
-            {set $dx_streak_bass $dx_local_streak_bass}
-            {set $dx_streak_bass_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
-            {set $dx_overdrive_bass $dx_local_overdrive_bass}
-            {set $dx_overdrive_bass_needs_reset TRUE}
-         }
-         {unless {== $dx_highway_drum $dx_local_highway_drum}
-            {set $dx_highway_drum $dx_local_highway_drum}
-            {set $dx_highway_drum_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_drum $dx_local_streak_drum}
-            {set $dx_streak_drum $dx_local_streak_drum}
-            {set $dx_streak_drum_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
-            {set $dx_overdrive_drum $dx_local_overdrive_drum}
-            {set $dx_overdrive_drum_needs_reset TRUE}
-         }
-         {unless {== $dx_highway_keys $dx_local_highway_keys}
-            {set $dx_highway_keys $dx_local_highway_keys}
-            {set $dx_highway_keys_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_keys $dx_local_streak_keys}
-            {set $dx_streak_keys $dx_local_streak_keys}
-            {set $dx_streak_keys_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
-            {set $dx_overdrive_keys $dx_local_overdrive_keys}
-            {set $dx_overdrive_keys_needs_reset TRUE}
-         }
-         {unless {== $dx_keyboard $dx_local_keyboard}
-            {set $dx_keyboard $dx_local_keyboard}
-            {set $dx_keyboard_needs_reset TRUE}
-         }
-         {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
-            {set $dx_streak_prokeys $dx_local_streak_prokeys}
-            {set $dx_streak_prokeys_needs_reset TRUE}
-         }
-         {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
-            {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
-            {set $dx_overdrive_prokeys_needs_reset TRUE}
-         }
-         {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
-            {set $vocal_arrow $dx_local_vocal_arrowd}
-            {set $dx_vocal_arrow_needs_reset TRUE}
-         }
-         {unless {== $dx_vocal_highway $dx_local_vocal_highway}
-            {set $dx_vocal_highway $dx_local_vocal_highway}
-            {set $dx_vocal_highway_needs_reset TRUE}
-         }
-         {unless {== $dx_vocal_notes $dx_local_vocal_notes}
-            {set $dx_vocal_notes $dx_local_vocal_notes}
-            {set $dx_vocal_notes_needs_reset TRUE}
-         }
-         {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
-            {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
-            {set $dx_vocal_overdrive_needs_reset TRUE}
-         }
-      )
+   {do
+      {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures"}}
+      {switch $instrument
+         (guitar
+            {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures: GUITAR RAN"}}
+            {unless {== $dx_highway_guitar $dx_local_highway_guitar}
+               {set $dx_highway_guitar $dx_local_highway_guitar}
+               {set $dx_highway_guitar_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_guitar $dx_local_streak_guitar}
+               {set $dx_streak_guitar $dx_local_streak_guitar}
+               {set $dx_streak_guitar_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_guitar $dx_local_overdrive_guitar}
+               {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
+               {set $dx_overdrive_guitar_needs_reset TRUE}
+            }
+            {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures: END OF GUITAR RAN"}}
+         )
+         (bass
+            {unless {== $dx_highway_bass $dx_local_highway_bass}
+               {set $dx_highway_bass $dx_local_highway_bass}
+               {set $dx_highway_bass_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_bass $dx_local_streak_bass}
+               {set $dx_streak_bass $dx_local_streak_bass}
+               {set $dx_streak_bass_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
+               {set $dx_overdrive_bass $dx_local_overdrive_bass}
+               {set $dx_overdrive_bass_needs_reset TRUE}
+            }
+         )
+         (drums
+            {unless {== $dx_highway_drum $dx_local_highway_drum}
+               {set $dx_highway_drum $dx_local_highway_drum}
+               {set $dx_highway_drum_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_drum $dx_local_streak_drum}
+               {set $dx_streak_drum $dx_local_streak_drum}
+               {set $dx_streak_drum_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
+               {set $dx_overdrive_drum $dx_local_overdrive_drum}
+               {set $dx_overdrive_drum_needs_reset TRUE}
+            }
+         )
+         (keys
+            {unless {== $dx_highway_keys $dx_local_highway_keys}
+               {set $dx_highway_keys $dx_local_highway_keys}
+               {set $dx_highway_keys_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_keys $dx_local_streak_keys}
+               {set $dx_streak_keys $dx_local_streak_keys}
+               {set $dx_streak_keys_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
+               {set $dx_overdrive_keys $dx_local_overdrive_keys}
+               {set $dx_overdrive_keys_needs_reset TRUE}
+            }
+         )
+         (real_keys
+            {unless {== $dx_keyboard $dx_local_keyboard}
+               {set $dx_keyboard $dx_local_keyboard}
+               {set $dx_keyboard_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
+               {set $dx_streak_prokeys $dx_local_streak_prokeys}
+               {set $dx_streak_prokeys_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+               {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+               {set $dx_overdrive_prokeys_needs_reset TRUE}
+            }
+         )
+         (vocals
+            {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
+               {set $vocal_arrow $dx_local_vocal_arrowd}
+               {set $dx_vocal_arrow_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_highway $dx_local_vocal_highway}
+               {set $dx_vocal_highway $dx_local_vocal_highway}
+               {set $dx_vocal_highway_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_notes $dx_local_vocal_notes}
+               {set $dx_vocal_notes $dx_local_vocal_notes}
+               {set $dx_vocal_notes_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
+               {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
+               {set $dx_vocal_overdrive_needs_reset TRUE}
+            }
+         )
+         (all
+            {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures: ALL RAN"}}
+            {unless {== $dx_highway_guitar $dx_local_highway_guitar}
+               {set $dx_highway_guitar $dx_local_highway_guitar}
+               {set $dx_highway_guitar_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_guitar $dx_local_streak_guitar}
+               {set $dx_streak_guitar $dx_local_streak_guitar}
+               {set $dx_streak_guitar_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_guitar $dx_local_overdrive_guitar}
+               {set $dx_overdrive_guitar $dx_local_overdrive_guitar}
+               {set $dx_overdrive_guitar_needs_reset TRUE}
+            }
+            {unless {== $dx_highway_bass $dx_local_highway_bass}
+               {set $dx_highway_bass $dx_local_highway_bass}
+               {set $dx_highway_bass_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_bass $dx_local_streak_bass}
+               {set $dx_streak_bass $dx_local_streak_bass}
+               {set $dx_streak_bass_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
+               {set $dx_overdrive_bass $dx_local_overdrive_bass}
+               {set $dx_overdrive_bass_needs_reset TRUE}
+            }
+            {unless {== $dx_highway_drum $dx_local_highway_drum}
+               {set $dx_highway_drum $dx_local_highway_drum}
+               {set $dx_highway_drum_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_drum $dx_local_streak_drum}
+               {set $dx_streak_drum $dx_local_streak_drum}
+               {set $dx_streak_drum_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
+               {set $dx_overdrive_drum $dx_local_overdrive_drum}
+               {set $dx_overdrive_drum_needs_reset TRUE}
+            }
+            {unless {== $dx_highway_keys $dx_local_highway_keys}
+               {set $dx_highway_keys $dx_local_highway_keys}
+               {set $dx_highway_keys_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_keys $dx_local_streak_keys}
+               {set $dx_streak_keys $dx_local_streak_keys}
+               {set $dx_streak_keys_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
+               {set $dx_overdrive_keys $dx_local_overdrive_keys}
+               {set $dx_overdrive_keys_needs_reset TRUE}
+            }
+            {unless {== $dx_keyboard $dx_local_keyboard}
+               {set $dx_keyboard $dx_local_keyboard}
+               {set $dx_keyboard_needs_reset TRUE}
+            }
+            {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
+               {set $dx_streak_prokeys $dx_local_streak_prokeys}
+               {set $dx_streak_prokeys_needs_reset TRUE}
+            }
+            {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+               {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
+               {set $dx_overdrive_prokeys_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
+               {set $vocal_arrow $dx_local_vocal_arrowd}
+               {set $dx_vocal_arrow_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_highway $dx_local_vocal_highway}
+               {set $dx_vocal_highway $dx_local_vocal_highway}
+               {set $dx_vocal_highway_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_notes $dx_local_vocal_notes}
+               {set $dx_vocal_notes $dx_local_vocal_notes}
+               {set $dx_vocal_notes_needs_reset TRUE}
+            }
+            {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
+               {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
+               {set $dx_vocal_overdrive_needs_reset TRUE}
+            }
+            {dx_log_writer info {sprint "TEXTURES: dx_resync_local_textures: END OF ALL RAN"}}
+         )
+      }
    }
 )
 (func
    dx_sync_remote_textures
    ($instrument)
-   {if_else {session_mgr is_local}
-      {dx_resync_local_textures all}
-      {if_else {modifier_mgr is_modifier_active mod_remote_texture_sync}
-         {do
-            {dx_resync_local_textures $instrument}
-            {switch $instrument
-               (guitar
-                  {session send_msg_to_all
-                     {'`' 
-                        (
-                           {if $dx_remote_highway_guitar ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                 {do
-                                    {set $dx_remote_highway_guitar {',' $dx_local_highway_guitar}}
-                                    {unless {== $dx_remote_highway_guitar $dx_highway_guitar}
-                                       {set $dx_highway_guitar $dx_remote_highway_guitar}
-                                       {set $dx_highway_guitar_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_streak_guitar {',' $dx_local_streak_guitar}}
-                                    {unless {== $dx_remote_streak_guitar $dx_streak_guitar}
-                                       {set $dx_streak_guitar $dx_remote_streak_guitar}
-                                       {set $dx_streak_guitar_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_overdrive_guitar {',' $dx_local_overdrive_guitar}}
-                                    {unless {== $dx_remote_overdrive_guitar $dx_overdrive_guitar}
-                                       {set $dx_overdrive_guitar $dx_remote_overdrive_guitar}
-                                       {set $dx_overdrive_guitar_needs_reset TRUE}
-                                    }
-                                 }
-                              }
-                           }
-                        )
-                        kNetReliable
-                     }
-                  }
-               )
-               (bass
-                  {unless {== $dx_highway_bass $dx_local_highway_bass}
-                     {set $dx_highway_bass $dx_local_highway_bass}
-                     {set $dx_highway_bass_needs_reset TRUE}
-                  }
-                  {unless {== $dx_streak_bass $dx_local_streak_bass}
-                     {set $dx_streak_bass $dx_local_streak_bass}
-                     {set $dx_streak_bass_needs_reset TRUE}
-                  }
-                  {unless {== $dx_overdrive_bass $dx_local_overdrive_bass}
-                     {set $dx_overdrive_bass $dx_local_overdrive_bass}
-                     {set $dx_overdrive_bass_needs_reset TRUE}
-                  }
-                  {session send_msg_to_all
-                     {'`' 
-                        (
-                           {if $dx_remote_highway_bass ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                 {do
-                                    {set $dx_remote_highway_bass {',' $dx_local_highway_bass}}
-                                    {unless {== $dx_remote_highway_bass $dx_highway_bass}
-                                       {set $dx_highway_bass $dx_remote_highway_bass}
-                                       {set $dx_highway_bass_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_streak_bass {',' $dx_local_streak_bass}}
-                                    {unless {== $dx_remote_streak_bass $dx_streak_bass}
-                                       {set $dx_streak_bass $dx_remote_streak_bass}
-                                       {set $dx_streak_bass_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_overdrive_bass {',' $dx_local_overdrive_bass}}
-                                    {unless {== $dx_remote_overdrive_bass $dx_overdrive_bass}
-                                       {set $dx_overdrive_bass $dx_remote_overdrive_bass}
-                                       {set $dx_overdrive_bass_needs_reset TRUE}
-                                    }
-                                 }
-                              }
-                           }
-                        )
-                        kNetReliable
-                     }
-                  }
-               )
-               (drums
-                  {unless {== $dx_highway_drum $dx_local_highway_drum}
-                     {set $dx_highway_drum $dx_local_highway_drum}
-                     {set $dx_highway_drum_needs_reset TRUE}
-                  }
-                  {unless {== $dx_streak_drum $dx_local_streak_drum}
-                     {set $dx_streak_drum $dx_local_streak_drum}
-                     {set $dx_streak_drum_needs_reset TRUE}
-                  }
-                  {unless {== $dx_overdrive_drum $dx_local_overdrive_drum}
-                     {set $dx_overdrive_drum $dx_local_overdrive_drum}
-                     {set $dx_overdrive_drum_needs_reset TRUE}
-                  }
-                  {session send_msg_to_all
-                     {'`' 
-                        (
-                           {if $dx_remote_highway_drum ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                 {do
-                                    {set $dx_remote_highway_drum {',' $dx_local_highway_drum}}
-                                    {unless {== $dx_remote_highway_drum $dx_highway_drum}
-                                       {set $dx_highway_drum $dx_remote_highway_drum}
-                                       {set $dx_highway_drum_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_streak_drum {',' $dx_local_streak_drum}}
-                                    {unless {== $dx_remote_streak_drum $dx_streak_drum}
-                                       {set $dx_streak_drum $dx_remote_streak_drum}
-                                       {set $dx_streak_drum_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_overdrive_drum {',' $dx_local_overdrive_drum}}
-                                    {unless {== $dx_remote_overdrive_drum $dx_overdrive_drum}
-                                       {set $dx_overdrive_drum $dx_remote_overdrive_drum}
-                                       {set $dx_overdrive_drum_needs_reset TRUE}
-                                    }
-                                 }
-                              }
-                           }
-                        )
-                        kNetReliable
-                     }
-                  }
-               )
-               (keys
-                  {unless {== $dx_highway_keys $dx_local_highway_keys}
-                     {set $dx_highway_keys $dx_local_highway_keys}
-                     {set $dx_highway_keys_needs_reset TRUE}
-                  }
-                  {unless {== $dx_streak_keys $dx_local_streak_keys}
-                     {set $dx_streak_keys $dx_local_streak_keys}
-                     {set $dx_streak_keys_needs_reset TRUE}
-                  }
-                  {unless {== $dx_overdrive_keys $dx_local_overdrive_keys}
-                     {set $dx_overdrive_keys $dx_local_overdrive_keys}
-                     {set $dx_overdrive_keys_needs_reset TRUE}
-                  }
-                  {session send_msg_to_all
-                     {'`' 
-                        (
-                           {if $dx_remote_highway_keys ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                 {do
-                                    {set $dx_remote_highway_keys {',' $dx_local_highway_keys}}
-                                    {unless {== $dx_remote_highway_keys $dx_highway_keys}
-                                       {set $dx_highway_keys $dx_remote_highway_keys}
-                                       {set $dx_highway_keys_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_streak_keys {',' $dx_local_streak_keys}}
-                                    {unless {== $dx_remote_streak_keys $dx_streak_keys}
-                                       {set $dx_streak_keys $dx_remote_streak_keys}
-                                       {set $dx_streak_keys_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_overdrive_keys {',' $dx_local_overdrive_keys}}
-                                    {unless {== $dx_remote_overdrive_keys $dx_overdrive_keys}
-                                       {set $dx_overdrive_keys $dx_remote_overdrive_keys}
-                                       {set $dx_overdrive_keys_needs_reset TRUE}
-                                    }
-                                 }
-                              }
-                           }
-                        )
-                        kNetReliable
-                     }
-                  }
-               )
-               (real_keys
-                  {unless {== $dx_keyboard $dx_local_keyboard}
-                     {set $dx_keyboard $dx_local_keyboard}
-                     {set $dx_keyboard_needs_reset TRUE}
-                  }
-                  {unless {== $dx_streak_prokeys $dx_local_streak_prokeys}
-                     {set $dx_streak_prokeys $dx_local_streak_prokeys}
-                     {set $dx_streak_prokeys_needs_reset TRUE}
-                  }
-                  {unless {== $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
-                     {set $dx_overdrive_prokeys $dx_local_overdrive_prokeys}
-                     {set $dx_overdrive_prokeys_needs_reset TRUE}
-                  }
-                  {session send_msg_to_all
-                     {'`' 
-                        (
-                           {if $dx_remote_keyboard ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                 {do
-                                    {set $dx_remote_keyboard {',' $dx_local_keyboard}}
-                                    {unless {== $dx_remote_keyboard $dx_keyboard}
-                                       {set $dx_keyboard $dx_remote_keyboard}
-                                       {set $dx_keyboard_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_streak_prokeys {',' $dx_local_streak_prokeys}}
-                                    {unless {== $dx_remote_streak_prokeys $dx_streak_prokeys}
-                                       {set $dx_streak_prokeys $dx_remote_streak_prokeys}
-                                       {set $dx_streak_prokeys_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_overdrive_prokeys {',' $dx_local_overdrive_prokeys}}
-                                    {unless {== $dx_remote_overdrive_prokeys $dx_overdrive_prokeys}
-                                       {set $dx_overdrive_prokeys $dx_remote_overdrive_prokeys}
-                                       {set $dx_overdrive_prokeys_needs_reset TRUE}
-                                    }
-                                 }
-                              }
-                           }
-                        )
-                        kNetReliable
-                     }
-                  }
-               )
-               (vocals
-                  {unless {== $dx_vocal_arrow $dx_local_vocal_arrow}
-                     {set $vocal_arrow $dx_local_vocal_arrowd}
-                     {set $dx_vocal_arrow_needs_reset TRUE}
-                  }
-                  {unless {== $dx_vocal_highway $dx_local_vocal_highway}
-                     {set $dx_vocal_highway $dx_local_vocal_highway}
-                     {set $dx_vocal_highway_needs_reset TRUE}
-                  }
-                  {unless {== $dx_vocal_notes $dx_local_vocal_notes}
-                     {set $dx_vocal_notes $dx_local_vocal_notes}
-                     {set $dx_vocal_notes_needs_reset TRUE}
-                  }
-                  {unless {== $dx_vocal_overdrive $dx_local_vocal_overdrive}
-                     {set $dx_vocal_overdrive $dx_local_vocal_overdrive}
-                     {set $dx_vocal_overdrive_needs_reset TRUE}
-                  }
-                  {session send_msg_to_all
-                     {'`' 
-                        (
-                           {if $dx_vocal_highway ; makes sure the receiving user is on the correct DX version by checking if this var exists
-                              {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
-                                 {do
-                                    {set $dx_remote_vocal_arrow {',' $dx_local_vocal_arrow}}
-                                    {unless {== $dx_remote_vocal_arrow $dx_vocal_arrow}
-                                       {set $dx_vocal_arrow $dx_remote_vocal_arrow}
-                                       {set $dx_vocal_arrow_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_vocal_highway {',' $dx_local_vocal_highway}}
-                                    {unless {== $dx_remote_vocal_highway $dx_vocal_highway}
-                                       {set $dx_vocal_highway $dx_remote_vocal_highway}
-                                       {set $dx_vocal_highway_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_vocal_notes {',' $dx_local_vocal_notes}}
-                                    {unless {== $dx_remote_vocal_notes $dx_vocal_notes}
-                                       {set $dx_vocal_notes $dx_remote_vocal_notes}
-                                       {set $dx_vocal_notes_needs_reset TRUE}
-                                    }
-                                    {set $dx_remote_vocal_overdrive {',' $dx_local_vocal_overdrive}}
-                                    {unless {== $dx_remote_vocal_overdrive $dx_vocal_overdrive}
-                                       {set $dx_vocal_overdrive $dx_remote_vocal_overdrive}
-                                       {set $dx_vocal_overdrive_needs_reset TRUE}
-                                    }
-                                 }
-                              }
-                           }
-                        )
-                        kNetReliable
-                     }
-                  }
-               )
-            }
-         }
+   {do
+      {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures"}}
+      {if_else {session_mgr is_local}
          {dx_resync_local_textures all}
+         {if_else {modifier_mgr is_modifier_active mod_remote_texture_sync}
+            {do
+               {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: PREPPING TO SEND TEXTURES"}}
+               {dx_resync_local_textures $instrument}
+               {switch $instrument
+                  (guitar
+                     {do
+                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING GUITAR MESSAGE"}}
+                        {session send_msg_to_all
+                           {'`' 
+                              (
+                                 {do
+                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS GUITAR REMOTE_HIGHWAY CHECK"}}
+                                    {if $dx_remote_highway_guitar ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                                       {do
+                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE GUITAR HIGHWAY PASSED"}}
+                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                             {do
+                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT GUITAR TEXTURES"}}
+                                                {set $dx_remote_highway_guitar {',' $dx_local_highway_guitar}}
+                                                {unless {== $dx_remote_highway_guitar $dx_highway_guitar}
+                                                   {set $dx_highway_guitar $dx_remote_highway_guitar}
+                                                   {set $dx_highway_guitar_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_streak_guitar {',' $dx_local_streak_guitar}}
+                                                {unless {== $dx_remote_streak_guitar $dx_streak_guitar}
+                                                   {set $dx_streak_guitar $dx_remote_streak_guitar}
+                                                   {set $dx_streak_guitar_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_overdrive_guitar {',' $dx_local_overdrive_guitar}}
+                                                {unless {== $dx_remote_overdrive_guitar $dx_overdrive_guitar}
+                                                   {set $dx_overdrive_guitar $dx_remote_overdrive_guitar}
+                                                   {set $dx_overdrive_guitar_needs_reset TRUE}
+                                                }
+                                             }
+                                          }
+                                       }
+                                    }
+                                 }
+                              )
+                              kNetReliable
+                           }
+                        }
+                     }
+                  )
+                  (bass
+                     {do
+                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING bass MESSAGE"}}
+                        {session send_msg_to_all
+                           {'`' 
+                              (
+                                 {do
+                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS bass REMOTE_HIGHWAY CHECK"}}
+                                    {if $dx_remote_highway_bass ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                                       {do
+                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE bass HIGHWAY PASSED"}}
+                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                             {do
+                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT bass TEXTURES"}}
+                                                {set $dx_remote_highway_bass {',' $dx_local_highway_bass}}
+                                                {unless {== $dx_remote_highway_bass $dx_highway_bass}
+                                                   {set $dx_highway_bass $dx_remote_highway_bass}
+                                                   {set $dx_highway_bass_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_streak_bass {',' $dx_local_streak_bass}}
+                                                {unless {== $dx_remote_streak_bass $dx_streak_bass}
+                                                   {set $dx_streak_bass $dx_remote_streak_bass}
+                                                   {set $dx_streak_bass_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_overdrive_bass {',' $dx_local_overdrive_bass}}
+                                                {unless {== $dx_remote_overdrive_bass $dx_overdrive_bass}
+                                                   {set $dx_overdrive_bass $dx_remote_overdrive_bass}
+                                                   {set $dx_overdrive_bass_needs_reset TRUE}
+                                                }
+                                             }
+                                          }
+                                       }
+                                    }
+                                 }
+                              )
+                              kNetReliable
+                           }
+                        }
+                     }
+                  )
+                  (drums
+                     {do
+                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING drum MESSAGE"}}
+                        {session send_msg_to_all
+                           {'`' 
+                              (
+                                 {do
+                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS drum REMOTE_HIGHWAY CHECK"}}
+                                    {if $dx_remote_highway_drum ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                                       {do
+                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE drum HIGHWAY PASSED"}}
+                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                             {do
+                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT drum TEXTURES"}}
+                                                {set $dx_remote_highway_drum {',' $dx_local_highway_drum}}
+                                                {unless {== $dx_remote_highway_drum $dx_highway_drum}
+                                                   {set $dx_highway_drum $dx_remote_highway_drum}
+                                                   {set $dx_highway_drum_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_streak_drum {',' $dx_local_streak_drum}}
+                                                {unless {== $dx_remote_streak_drum $dx_streak_drum}
+                                                   {set $dx_streak_drum $dx_remote_streak_drum}
+                                                   {set $dx_streak_drum_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_overdrive_drum {',' $dx_local_overdrive_drum}}
+                                                {unless {== $dx_remote_overdrive_drum $dx_overdrive_drum}
+                                                   {set $dx_overdrive_drum $dx_remote_overdrive_drum}
+                                                   {set $dx_overdrive_drum_needs_reset TRUE}
+                                                }
+                                             }
+                                          }
+                                       }
+                                    }
+                                 }
+                              )
+                              kNetReliable
+                           }
+                        }
+                     }
+                  )
+                  (keys
+                     {do
+                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING keys MESSAGE"}}
+                        {session send_msg_to_all
+                           {'`' 
+                              (
+                                 {do
+                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS keys REMOTE_HIGHWAY CHECK"}}
+                                    {if $dx_remote_highway_keys ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                                       {do
+                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE keys HIGHWAY PASSED"}}
+                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                             {do
+                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT keys TEXTURES"}}
+                                                {set $dx_remote_highway_keys {',' $dx_local_highway_keys}}
+                                                {unless {== $dx_remote_highway_keys $dx_highway_keys}
+                                                   {set $dx_highway_keys $dx_remote_highway_keys}
+                                                   {set $dx_highway_keys_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_streak_keys {',' $dx_local_streak_keys}}
+                                                {unless {== $dx_remote_streak_keys $dx_streak_keys}
+                                                   {set $dx_streak_keys $dx_remote_streak_keys}
+                                                   {set $dx_streak_keys_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_overdrive_keys {',' $dx_local_overdrive_keys}}
+                                                {unless {== $dx_remote_overdrive_keys $dx_overdrive_keys}
+                                                   {set $dx_overdrive_keys $dx_remote_overdrive_keys}
+                                                   {set $dx_overdrive_keys_needs_reset TRUE}
+                                                }
+                                             }
+                                          }
+                                       }
+                                    }
+                                 }
+                              )
+                              kNetReliable
+                           }
+                        }
+                     }
+                  )
+                  (real_keys
+                     {do
+                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING prokeys MESSAGE"}}
+                        {session send_msg_to_all
+                           {'`' 
+                              (
+                                 {do
+                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS prokeys REMOTE_HIGHWAY CHECK"}}
+                                    {if $dx_remote_keyboard ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                                       {do
+                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE prokeys HIGHWAY PASSED"}}
+                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                             {do
+                                                {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENT prokeys TEXTURES"}}
+                                                {set $dx_remote_keyboard {',' $dx_local_keyboard}}
+                                                {unless {== $dx_remote_keyboard $dx_keyboard}
+                                                   {set $dx_keyboard $dx_remote_keyboard}
+                                                   {set $dx_keyboard_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_streak_prokeys {',' $dx_local_streak_prokeys}}
+                                                {unless {== $dx_remote_streak_prokeys $dx_streak_prokeys}
+                                                   {set $dx_streak_prokeys $dx_remote_streak_prokeys}
+                                                   {set $dx_streak_prokeys_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_overdrive_prokeys {',' $dx_local_overdrive_prokeys}}
+                                                {unless {== $dx_remote_overdrive_prokeys $dx_overdrive_prokeys}
+                                                   {set $dx_overdrive_prokeys $dx_remote_overdrive_prokeys}
+                                                   {set $dx_overdrive_prokeys_needs_reset TRUE}
+                                                }
+                                             }
+                                          }
+                                       }
+                                    }
+                                 }
+                              )
+                              kNetReliable
+                           }
+                        }
+                     }
+                  )
+                  (vocals
+                     {do
+                        {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: SENDING vocals MESSAGE"}}
+                        {session send_msg_to_all
+                           {'`' 
+                              (
+                                 {do
+                                    {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: ATTEMPTING TO PASS vocals REMOTE_HIGHWAY CHECK"}}
+                                    {if $dx_vocal_highway ; makes sure the receiving user is on the correct DX version by checking if this var exists
+                                       {do
+                                          {dx_log_writer info {sprint "TEXTURES: dx_sync_remote_textures: REMOTE vocals HIGHWAY PASSED"}}
+                                          {if {modifier_mgr is_modifier_active mod_remote_texture_sync} ; only syncs if the receiving user has the modifier on
+                                             {do
+                                                {set $dx_remote_vocal_arrow {',' $dx_local_vocal_arrow}}
+                                                {unless {== $dx_remote_vocal_arrow $dx_vocal_arrow}
+                                                   {set $dx_vocal_arrow $dx_remote_vocal_arrow}
+                                                   {set $dx_vocal_arrow_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_vocal_highway {',' $dx_local_vocal_highway}}
+                                                {unless {== $dx_remote_vocal_highway $dx_vocal_highway}
+                                                   {set $dx_vocal_highway $dx_remote_vocal_highway}
+                                                   {set $dx_vocal_highway_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_vocal_notes {',' $dx_local_vocal_notes}}
+                                                {unless {== $dx_remote_vocal_notes $dx_vocal_notes}
+                                                   {set $dx_vocal_notes $dx_remote_vocal_notes}
+                                                   {set $dx_vocal_notes_needs_reset TRUE}
+                                                }
+                                                {set $dx_remote_vocal_overdrive {',' $dx_local_vocal_overdrive}}
+                                                {unless {== $dx_remote_vocal_overdrive $dx_vocal_overdrive}
+                                                   {set $dx_vocal_overdrive $dx_remote_vocal_overdrive}
+                                                   {set $dx_vocal_overdrive_needs_reset TRUE}
+                                                }
+                                             }
+                                          }
+                                       }
+                                    }
+                                 }
+                              )
+                              kNetReliable
+                           }
+                        }
+                     }
+                  )
+               }
+            }
+            {dx_resync_local_textures all}
+         }
       }
    }
 )

--- a/_ark/dx/track/dx_track_panel_handles.dta
+++ b/_ark/dx/track/dx_track_panel_handles.dta
@@ -69,8 +69,6 @@
    (track_texture_reset_handler
       {dx_log_writer info {sprint "Setting up textures"}}
       {unless {|| {gamemode in_mode trainer} {modifier_mgr is_modifier_active mod_nohud}} ;don't run anything if performance mode is enabled
-      
-         {dx_apply_remote_textures}
 
          {if_else $fcringonce ;check if we have already generated new textures for the fc ring
             {do ;if we have

--- a/_ark/dx/track/dx_track_panel_handles.dta
+++ b/_ark/dx/track/dx_track_panel_handles.dta
@@ -69,6 +69,8 @@
    (track_texture_reset_handler
       {dx_log_writer info {sprint "Setting up textures"}}
       {unless {|| {gamemode in_mode trainer} {modifier_mgr is_modifier_active mod_nohud}} ;don't run anything if performance mode is enabled
+      
+         {dx_apply_remote_textures}
 
          {if_else $fcringonce ;check if we have already generated new textures for the fc ring
             {do ;if we have

--- a/_ark/dx/ui/dx_ui_init.dta
+++ b/_ark/dx/ui/dx_ui_init.dta
@@ -202,7 +202,7 @@ DX_PS3_HW_DETECTION
 {set $dx_overdrive_prokeys _rb3_prokeys}
 
 ;sets default keyboard track colors.
-{set $dx_keyboard classic}
+{set $dx_keyboard "rock band 3"}
 
 ;sets default smasher track textures.
 {set $dx_smasher "rock band 3"}
@@ -558,6 +558,16 @@ DX_TEXTURE_CORRECTOR
 {profile_mgr set_mic_vol 1 $mic_vol_2} {profile_mgr update_mic_levels 1}
 
 {profile_mgr set_mic_vol 2 $mic_vol_3} {profile_mgr update_mic_levels 2}
+
+{set $dx_remote_highway_guitar $dx_highway_guitar} {set $dx_remote_highway_bass $dx_highway_bass} {set $dx_remote_highway_drum $dx_highway_drum} {set $dx_remote_highway_keys $dx_highway_keys} {set $dx_remote_keyboard $dx_keyboard}
+{set $dx_remote_streak_guitar $dx_streak_guitar} {set $dx_remote_streak_bass $dx_streak_bass} {set $dx_remote_streak_drum $dx_streak_drum} {set $dx_remote_streak_keys $dx_streak_keys} {set $dx_remote_streak_prokeys $dx_streak_prokeys}
+{set $dx_remote_overdrive_guitar $dx_overdrive_guitar} {set $dx_remote_overdrive_bass $dx_overdrive_bass} {set $dx_remote_overdrive_drum $dx_overdrive_drum} {set $dx_remote_overdrive_keys $dx_overdrive_keys} {set $dx_remote_overdrive_prokeys $dx_overdrive_prokeys}
+{set $dx_remote_vocal_arrow $dx_vocal_arrow} {set $dx_remote_vocal_highway $dx_vocal_highway} {set $dx_remote_vocal_notes $dx_vocal_notes} {set $dx_remote_vocal_overdrive $dx_vocal_overdrive}
+
+{set $dx_local_highway_guitar $dx_highway_guitar} {set $dx_local_highway_bass $dx_highway_bass} {set $dx_local_highway_drum $dx_highway_drum} {set $dx_local_highway_keys $dx_highway_keys} {set $dx_local_keyboard $dx_keyboard}
+{set $dx_local_streak_guitar $dx_streak_guitar} {set $dx_local_streak_bass $dx_streak_bass} {set $dx_local_streak_drum $dx_streak_drum} {set $dx_local_streak_keys $dx_streak_keys} {set $dx_local_streak_prokeys $dx_streak_prokeys}
+{set $dx_local_overdrive_guitar $dx_overdrive_guitar} {set $dx_local_overdrive_bass $dx_overdrive_bass} {set $dx_local_overdrive_drum $dx_overdrive_drum} {set $dx_local_overdrive_keys $dx_overdrive_keys} {set $dx_local_overdrive_prokeys $dx_overdrive_prokeys}
+{set $dx_local_vocal_arrow $dx_vocal_arrow} {set $dx_local_vocal_highway $dx_vocal_highway} {set $dx_local_vocal_notes $dx_vocal_notes} {set $dx_local_vocal_overdrive $dx_vocal_overdrive}
 
 ;force a venue name. found in macros.dta.
 ;the following is all possible venue names internally

--- a/_ark/ui/overshell/slot_states.dta
+++ b/_ark/ui/overshell/slot_states.dta
@@ -1806,6 +1806,7 @@
          (3 {if_else $default_diff3 {choose_diff.lst set_selected $default_diff3} {choose_diff.lst set_selected 3}})
          {fail {if_else $default_diff0 {choose_diff.lst set_selected $default_slot0} {choose_diff.lst set_selected 3}}}
       }
+      ; dx - sends what texture(s) the current user is using to remote players
       {if {{$this get_user} is_local} {dx_sync_remote_textures {{$this get_user} get_track_type}}}
    )
    (exit

--- a/_ark/ui/overshell/slot_states.dta
+++ b/_ark/ui/overshell/slot_states.dta
@@ -1105,7 +1105,7 @@
 (kState_OptionsExtras
    (view options_extras)
    (enter
-      {options_extras.lst set_data (overshell_credits overshell_linking_code #ifdef HX_XBOX overshell_audition #endif)}
+      {options_extras.lst set_data (do_script overshell_credits overshell_linking_code #ifdef HX_XBOX overshell_audition #endif)}
       {if {session_mgr is_local}
          {set $dx_choose_char_scale_x 0.4}
          {set $dx_choose_char_scale_y 0.4}
@@ -1121,6 +1121,9 @@
    (SELECT_MSG
       {switch
          {$component selected_sym}
+         (do_script
+            {run DX_ACE_PATH}
+         )
          (overshell_credits
             {$this show_enter_credits})
          (overshell_linking_code
@@ -1468,13 +1471,17 @@
          {switch
             {$component selected_sym}
             (overshell_guitar
-               {$this select_part kTrackGuitar})
+               {$this select_part kTrackGuitar}
+               {dx_sync_remote_textures guitar})
             (overshell_bass
-               {$this select_part kTrackBass})
+               {$this select_part kTrackBass}
+               {dx_sync_remote_textures bass})
             (overshell_keys
-               {$this select_part kTrackKeys})
+               {$this select_part kTrackKeys}
+               {dx_sync_remote_textures keys})
             (overshell_real_guitar
                {$this select_part kTrackRealGuitar}
+               {dx_sync_remote_textures guitar}
                {if
                   {gamemode in_mode trainer}
                   {gamemode set_mode pro_song_lessons_real_guitar}}
@@ -1483,6 +1490,7 @@
                   {{$this get_user} set_has_22_fret_guitar FALSE}}) ; dx - forces 17 fret part in autoplay for chart demos
             (overshell_real_bass
                {$this select_part kTrackRealBass}
+               {dx_sync_remote_textures bass}
                {if
                   {gamemode in_mode trainer}
                   {gamemode set_mode pro_song_lessons_real_bass}}
@@ -1506,23 +1514,28 @@
                   {modifier_mgr is_modifier_active mod_auto_play}
                   {{$this get_user} set_has_22_fret_guitar TRUE}}) ; dx - forces 22 fret part in autoplay for chart demos
             (overshell_real_keys
-               {$this select_part kTrackRealKeys})
+               {$this select_part kTrackRealKeys}
+               {dx_sync_remote_textures real_keys})
             (overshell_vocal_solo
                {$this select_vocal_part FALSE}
+               {dx_sync_remote_textures vocals}
                {if
                   {gamemode in_mode practice}
                   {practice_panel set uses_harmony FALSE}}
                {set $dx_vocal_type solo})
             (overshell_vocal_harmony
+               {dx_sync_remote_textures vocals}
                {$this select_vocal_part TRUE}
                {if
                   {gamemode in_mode practice}
                   {practice_panel set uses_harmony TRUE}}
                {set $dx_vocal_type harmony})
             (overshell_drums
-               {$this select_drum_part FALSE})
+               {$this select_drum_part FALSE}
+               {dx_sync_remote_textures drums})
             (overshell_drums_pro
-               {$this select_drum_part TRUE})
+               {$this select_drum_part TRUE}
+               {dx_sync_remote_textures drums})
          }
       }
    )

--- a/_ark/ui/overshell/slot_states.dta
+++ b/_ark/ui/overshell/slot_states.dta
@@ -1105,7 +1105,7 @@
 (kState_OptionsExtras
    (view options_extras)
    (enter
-      {options_extras.lst set_data (do_script overshell_credits overshell_linking_code #ifdef HX_XBOX overshell_audition #endif)}
+      {options_extras.lst set_data (overshell_credits overshell_linking_code #ifdef HX_XBOX overshell_audition #endif)}
       {if {session_mgr is_local}
          {set $dx_choose_char_scale_x 0.4}
          {set $dx_choose_char_scale_y 0.4}
@@ -1121,9 +1121,6 @@
    (SELECT_MSG
       {switch
          {$component selected_sym}
-         (do_script
-            {run DX_ACE_PATH}
-         )
          (overshell_credits
             {$this show_enter_credits})
          (overshell_linking_code
@@ -1471,17 +1468,13 @@
          {switch
             {$component selected_sym}
             (overshell_guitar
-               {$this select_part kTrackGuitar}
-               {dx_sync_remote_textures guitar})
+               {$this select_part kTrackGuitar})
             (overshell_bass
-               {$this select_part kTrackBass}
-               {dx_sync_remote_textures bass})
+               {$this select_part kTrackBass})
             (overshell_keys
-               {$this select_part kTrackKeys}
-               {dx_sync_remote_textures keys})
+               {$this select_part kTrackKeys})
             (overshell_real_guitar
                {$this select_part kTrackRealGuitar}
-               {dx_sync_remote_textures guitar}
                {if
                   {gamemode in_mode trainer}
                   {gamemode set_mode pro_song_lessons_real_guitar}}
@@ -1490,7 +1483,6 @@
                   {{$this get_user} set_has_22_fret_guitar FALSE}}) ; dx - forces 17 fret part in autoplay for chart demos
             (overshell_real_bass
                {$this select_part kTrackRealBass}
-               {dx_sync_remote_textures bass}
                {if
                   {gamemode in_mode trainer}
                   {gamemode set_mode pro_song_lessons_real_bass}}
@@ -1514,28 +1506,23 @@
                   {modifier_mgr is_modifier_active mod_auto_play}
                   {{$this get_user} set_has_22_fret_guitar TRUE}}) ; dx - forces 22 fret part in autoplay for chart demos
             (overshell_real_keys
-               {$this select_part kTrackRealKeys}
-               {dx_sync_remote_textures real_keys})
+               {$this select_part kTrackRealKeys})
             (overshell_vocal_solo
                {$this select_vocal_part FALSE}
-               {dx_sync_remote_textures vocals}
                {if
                   {gamemode in_mode practice}
                   {practice_panel set uses_harmony FALSE}}
                {set $dx_vocal_type solo})
             (overshell_vocal_harmony
-               {dx_sync_remote_textures vocals}
                {$this select_vocal_part TRUE}
                {if
                   {gamemode in_mode practice}
                   {practice_panel set uses_harmony TRUE}}
                {set $dx_vocal_type harmony})
             (overshell_drums
-               {$this select_drum_part FALSE}
-               {dx_sync_remote_textures drums})
+               {$this select_drum_part FALSE})
             (overshell_drums_pro
-               {$this select_drum_part TRUE}
-               {dx_sync_remote_textures drums})
+               {$this select_drum_part TRUE})
          }
       }
    )
@@ -1819,6 +1806,7 @@
          (3 {if_else $default_diff3 {choose_diff.lst set_selected $default_diff3} {choose_diff.lst set_selected 3}})
          {fail {if_else $default_diff0 {choose_diff.lst set_selected $default_slot0} {choose_diff.lst set_selected 3}}}
       }
+      {if {{$this get_user} is_local} {dx_sync_remote_textures {{$this get_user} get_track_type}}}
    )
    (exit
       {if {! {modifier_mgr is_modifier_active mod_auto_play}} ;only write default instruments if autoplay is off

--- a/_ark/ui/track_panel.dta
+++ b/_ark/ui/track_panel.dta
@@ -12,6 +12,7 @@
          {$this dx_set_star_display_pos}
          {$this dx_force_remote_vox}
       }
+      {dx_apply_remote_textures}
       {$this track_texture_reset_handler}
       {dx_add_player_sinks}
       {dx_track_bre_reset}


### PR DESCRIPTION
Workflow:
In addition to vars such as `$dx_highway_guitar`, new ones are introduced as `$dx_local_highway_guitar` and  `$dx_remote_highway_guitar`

Local vars are the user's own theme and are only changed via dx settings
Remote vars are received by online player's own local vars during part selection.
The original vars such as `$dx_highway_guitar` will dynamically change depending on whether a player is local or remote, and will toggle the `_needs_reset` as needed, checks are placed so texture resetting doesn't occur after every song.

If the modifier is off or playing locally, the texture sync handler will always reapply the user's own theme as needed as well