### PR TITLE
Load all region DLC/customs on PS3

### DIFF
--- a/_ark/config/system.dta
+++ b/_ark/config/system.dta
@@ -1,0 +1,125 @@
+(language
+   (default eng)
+   (supported
+      (eng fre ita deu esl))
+   (remap
+      (mex esl))
+   #ifndef _SHIP
+   (cheat_supported
+      (eng fre ita deu esl))
+   #endif)
+(ng TRUE)
+(xbox_map_file
+   "%s/band_%s.map")
+#ifdef HX_PS3
+(commerce_container TRUE)
+(init_https TRUE)
+(trophies TRUE)
+(np_communication_id
+   "NPWR00985_00")
+(titles
+   #ifdef REGION_NA
+   (band3
+      (title_id
+         (live
+            "BLUS30463")
+         (test
+            "NPXX00000"))
+      (service_id
+         (live
+            "UP8802-BLUS30463_00")
+         (test
+            "UP0006-NPXX00000_00")))
+   (band3_eur
+      (title_id
+         (live
+            "BLES00986")
+         (test
+            "NPXX00000"))
+      (service_id
+         (live
+            "EP0006-BLES00986_00")
+         (test
+            "UP0006-NPXX00000_00")))
+   #else
+   #ifdef REGION_EUROPE
+   (band3
+      (title_id
+         (live
+            "BLES00986")
+         (test
+            "NPXX00000"))
+      (service_id
+         (live
+            "EP0006-BLES00986_00")
+         (test
+            "UP0006-NPXX00000_00")))
+   (band3_usa
+      (title_id
+         (live
+            "BLUS30463")
+         (test
+            "NPXX00000"))
+      (service_id
+         (live
+            "UP8802-BLUS30463_00")
+         (test
+            "UP0006-NPXX00000_00")))
+   #endif
+   #endif
+   (band3_patch
+      (title_id
+         (live
+            "BLES01611")
+         (test
+            "NPXX00000"))
+      (service_id
+         (live
+            "EP8802-BLES01611_00")
+         (test
+            "UP0006-NPXX00000_00")))
+   (rb2_usa
+      (title_id
+         (live
+            "BLUS30147")
+         (test
+            "NPXX00360"))
+      (service_id
+         (live
+            "UP0006-BLUS30147_00")
+         (test
+            "UP0006-NPXX00360_00")))
+   (rb1_usa
+      (title_id
+         (live
+            "BLUS30050")
+         (test
+            "NPXX00202"))
+      (service_id
+         (live
+            "UP0006-BLUS30050_00")
+         (test
+            "UD2464-NPXX00202_00")))
+   (rb2_eur
+      (title_id
+         (live
+            "BLES00385")
+         (test
+            "BLES00385"))
+      (service_id
+         (live
+            "EP0006-BLES00385_00")
+         (test
+            "EP0006-BLES00385_00")))
+   (rb1_eur
+      (title_id
+         (live
+            "BLES00228")
+         (test
+            "NPXX00202"))
+      (service_id
+         (live
+            "EP0006-BLES00228_00")
+         (test
+            "UD2464-NPXX00202_00"))))
+#endif


### PR DESCRIPTION
Adds `config/system.dta` from 1.06 (BLES00986) and re-orders it in order to load all DLC, regardless of title ID, on both regions of the game, as well as adding the BLES01611 title ID used for some late RB3 DLC in EUR regions.

Only tested on RPCS3, probably needs testing on CFW and HEN.

The load order is ordered in a way that will make RB3Enhanced on PS3 ignore its own all-region loading feature (loads a EUR title ID before USA load order is completed, and vice versa - see `TitleIDRegisterHook` in https://github.com/InvoxiPlayGames/RB3Enhanced/blob/ps3sdk/source/ps3.c)

Might also be worth making it an optional toggle, in case someone has 2 copies of the game installed intentionally for DLC/DX/Enhanced switching.