### PR TITLE
hide "You can use pretty much any microphone to sing." tip on Wii

### DIFF
--- a/_ark/dx/ui/loading/dx_loading_tips.dta
+++ b/_ark/dx/ui/loading/dx_loading_tips.dta
@@ -51,7 +51,9 @@
          "You can buy a real guitar for pretty cheap - maybe it's time to invest."
          "Wanna make even more noise? Buy a real drum kit."
          "The louder the better!"
+         #ifndef HX_WII
          "You can use pretty much any microphone to sing."
+         #endif
          "Play flawlessly to get a score multiplier going. The longer you hold a streak, the higher your multiplier will get."
          "If you see a series of glowing notes, hit it perfectly to gain Energy."
          "Take a moment to set your drum controller to the right height. It makes a big difference."


### PR DESCRIPTION
gated "You can use pretty much any microphone to sing." loading tip behind an `#ifndef HX_WII` since Wii only supports Logitech microphones