### PR TITLE
Add "Rock Band en Español" origin

### DIFF
--- a/_ark/dx/locale/dx_locale_sources.dta
+++ b/_ark/dx/locale/dx_locale_sources.dta
@@ -282,6 +282,7 @@
 (revolved "REVOLVED")
 (ugc_rv "RhythmVerse Customs")
 (rhythmverse "RhythmVerse Customs")
+(rbee "Rock Band en Español")
 (rsp "Russian Song Pack")
 (scorespy "ScoreSpy")
 (soi "Shadow of Intent Discography")


### PR DESCRIPTION
Spoke with the "Rock Band en Español" group and they agreed with this origin code. This is probably the only way to filter by a specific language for the time being. PLAY PLAY A SHOW IN SPANISH!