### PR TITLE
Add YARG DLC source

### DIFF
--- a/_ark/dx/locale/dx_locale_sources.dta
+++ b/_ark/dx/locale/dx_locale_sources.dta
@@ -141,6 +141,7 @@
 (scgmd4 "Super Crazy Guitar Maniac Deluxe 4")
 (scgmd "Super Crazy Guitar Maniac Deluxe Series")
 (yarg "YARG")
+(yargdlc "YARG DLC")
 
 ; Community sources
 (311hero "311 Hero")


### PR DESCRIPTION
YARG is starting to get multiple DLC packs in addition to its "official setlist" pack, so I figure it wouldn't hurt to add a source with them for consistency with other games that have DLC.