### PR TITLE
Persist pad button remaps across reboots

### DIFF
--- a/_ark/dx/overshell/dx_controller_states.dta
+++ b/_ark/dx/overshell/dx_controller_states.dta
@@ -326,6 +326,7 @@
                            }
                         }
                         {set_elem {find $syscfg beatmatcher controller joypad slots} 1 {elem $dx_button_list $dx_button_0_array_num}}
+                        {set $dx_joypad_pad_remap_0 {elem $dx_button_list $dx_button_0_array_num}}
                      }
                      {set $dx_list_pos 0}
                   )
@@ -342,6 +343,7 @@
                            }
                         }
                         {set_elem {find $syscfg beatmatcher controller joypad slots} 3 {elem $dx_button_list $dx_button_1_array_num}}
+                        {set $dx_joypad_pad_remap_1 {elem $dx_button_list $dx_button_1_array_num}}
                      }
                      {set $dx_list_pos 1}
                   )
@@ -358,6 +360,7 @@
                            }
                         }
                         {set_elem {find $syscfg beatmatcher controller joypad slots} 5 {elem $dx_button_list $dx_button_2_array_num}}
+                        {set $dx_joypad_pad_remap_2 {elem $dx_button_list $dx_button_2_array_num}}
                      }
                      {set $dx_list_pos 2}
                   )
@@ -374,6 +377,7 @@
                            }
                         }
                         {set_elem {find $syscfg beatmatcher controller joypad slots} 7 {elem $dx_button_list $dx_button_3_array_num}}
+                        {set $dx_joypad_pad_remap_3 {elem $dx_button_list $dx_button_3_array_num}}
                      }
                      {set $dx_list_pos 3}
                   )
@@ -390,6 +394,7 @@
                            }
                         }
                         {set_elem {find $syscfg beatmatcher controller joypad slots} 9 {elem $dx_button_list $dx_button_4_array_num}}
+                        {set $dx_joypad_pad_remap_4 {elem $dx_button_list $dx_button_4_array_num}}
                      }
                      {set $dx_list_pos 4}
                   )
@@ -406,6 +411,7 @@
                            }
                         }
                         {set_elem {find $syscfg beatmatcher controller joypad force_mercury} 1 {elem $dx_button_list $dx_button_5_array_num}}
+                        {set $dx_joypad_pad_remap_5 {elem $dx_button_list $dx_button_5_array_num}}
                      }
                      {set $dx_list_pos 5}
                   )
@@ -529,6 +535,8 @@
       }
    )
    (on_cancel
+      {if {! $dx_prompt_save}
+         {dx_settings_dta_writer}}
       {$this show_state dxState_ControllerMenu}
    )
 )

--- a/_ark/dx/read_write/dx_reader_macros.dta
+++ b/_ark/dx/read_write/dx_reader_macros.dta
@@ -420,6 +420,36 @@
          {elem {find $entry dx_joypad_pad_mapping} 1}
       }
    }
+   {if {== {elem $entry 0} {basename dx_joypad_pad_remap_0}}
+      {set $dx_joypad_pad_remap_0
+         {elem {find $entry dx_joypad_pad_remap_0} 1}
+      }
+   }
+   {if {== {elem $entry 0} {basename dx_joypad_pad_remap_1}}
+      {set $dx_joypad_pad_remap_1
+         {elem {find $entry dx_joypad_pad_remap_1} 1}
+      }
+   }
+   {if {== {elem $entry 0} {basename dx_joypad_pad_remap_2}}
+      {set $dx_joypad_pad_remap_2
+         {elem {find $entry dx_joypad_pad_remap_2} 1}
+      }
+   }
+   {if {== {elem $entry 0} {basename dx_joypad_pad_remap_3}}
+      {set $dx_joypad_pad_remap_3
+         {elem {find $entry dx_joypad_pad_remap_3} 1}
+      }
+   }
+   {if {== {elem $entry 0} {basename dx_joypad_pad_remap_4}}
+      {set $dx_joypad_pad_remap_4
+         {elem {find $entry dx_joypad_pad_remap_4} 1}
+      }
+   }
+   {if {== {elem $entry 0} {basename dx_joypad_pad_remap_5}}
+      {set $dx_joypad_pad_remap_5
+         {elem {find $entry dx_joypad_pad_remap_5} 1}
+      }
+   }
    {if {== {elem $entry 0} {basename dx_instrument_icons}}
       {set $dx_instrument_icons
          {elem {find $entry dx_instrument_icons} 1}

--- a/_ark/dx/read_write/dx_writer_macros.dta
+++ b/_ark/dx/read_write/dx_writer_macros.dta
@@ -99,6 +99,12 @@
    {dx_setting_saver dx_settings dx_joypad_type_keys $dx_joypad_type_keys}
    {dx_setting_saver dx_settings dx_joypad_type_vocals $dx_joypad_type_vocals}
    {dx_setting_saver dx_settings dx_joypad_pad_mapping $dx_joypad_pad_mapping}
+   {dx_setting_saver dx_settings dx_joypad_pad_remap_0 $dx_joypad_pad_remap_0}
+   {dx_setting_saver dx_settings dx_joypad_pad_remap_1 $dx_joypad_pad_remap_1}
+   {dx_setting_saver dx_settings dx_joypad_pad_remap_2 $dx_joypad_pad_remap_2}
+   {dx_setting_saver dx_settings dx_joypad_pad_remap_3 $dx_joypad_pad_remap_3}
+   {dx_setting_saver dx_settings dx_joypad_pad_remap_4 $dx_joypad_pad_remap_4}
+   {dx_setting_saver dx_settings dx_joypad_pad_remap_5 $dx_joypad_pad_remap_5}
    {dx_setting_saver dx_settings dx_overshell_theme $dx_overshell_theme}
    {dx_setting_saver dx_settings dx_player_icons $dx_player_icons}
    {dx_setting_saver dx_settings dx_instrument_icons $dx_instrument_icons}

--- a/_ark/dx/ui/dx_ui_init.dta
+++ b/_ark/dx/ui/dx_ui_init.dta
@@ -712,6 +712,12 @@ DX_CURRENT_SONG_CLEAR
 {set $dx_joypad_type_keys kControllerKeys}
 {set $dx_joypad_type_vocals kControllerVocals}
 {set $dx_joypad_pad_mapping joypad}
+{set $dx_joypad_pad_remap_0 kPad_L2}
+{set $dx_joypad_pad_remap_1 kPad_L1}
+{set $dx_joypad_pad_remap_2 kPad_R1}
+{set $dx_joypad_pad_remap_3 kPad_R2}
+{set $dx_joypad_pad_remap_4 kPad_X}
+{set $dx_joypad_pad_remap_5 kPad_Select}
 
 ;mtv overlay position for event mode
 ;{if $dx_event_mode
@@ -944,6 +950,22 @@ DX_CURRENT_SONG_CLEAR
 
 {unless {== $dx_joypad_pad_mapping joypad} {do DX_REMAP_PAD}}
 
+{set_elem {find $syscfg beatmatcher controller joypad slots} 1 $dx_joypad_pad_remap_0}
+{set_elem {find $syscfg beatmatcher controller joypad slots} 3 $dx_joypad_pad_remap_1}
+{set_elem {find $syscfg beatmatcher controller joypad slots} 5 $dx_joypad_pad_remap_2}
+{set_elem {find $syscfg beatmatcher controller joypad slots} 7 $dx_joypad_pad_remap_3}
+{set_elem {find $syscfg beatmatcher controller joypad slots} 9 $dx_joypad_pad_remap_4}
+{set_elem {find $syscfg beatmatcher controller joypad force_mercury} 1 $dx_joypad_pad_remap_5}
+
+{set $dx_button_0_array_num $dx_joypad_pad_remap_0}
+{set $dx_button_1_array_num $dx_joypad_pad_remap_1}
+{set $dx_button_2_array_num $dx_joypad_pad_remap_2}
+{set $dx_button_3_array_num $dx_joypad_pad_remap_3}
+{set $dx_button_4_array_num $dx_joypad_pad_remap_4}
+{set $dx_button_5_array_num $dx_joypad_pad_remap_5}
+
+
+
 ;reset textures and angle if set to rb3
 {do {dx_default_texture_var_reset} {dx_track_angle_var_reset}}
 
@@ -967,12 +989,6 @@ DX_CURRENT_SONG_CLEAR
 
 {set $dx_last_song_has_tonic FALSE}
 
-{set $dx_button_0_array_num kPad_L2}
-{set $dx_button_1_array_num kPad_L1}
-{set $dx_button_2_array_num kPad_R1}
-{set $dx_button_3_array_num kPad_R2}
-{set $dx_button_4_array_num kPad_X}
-{set $dx_button_5_array_num kPad_Select}
 
 ;force a venue name. found in macros.dta.
 ;the following is all possible venue names internally


### PR DESCRIPTION
Saves the mappings for pad mode in `dx_settings.dta` as `dx_joypad_pad_remap_[0-5]`
Respects settings prompt save setting