### PR TITLE
Residual fix of old lights with upgrades

### DIFF
--- a/_ark/config/midi_parsers.dta
+++ b/_ark/config/midi_parsers.dta
@@ -2173,7 +2173,13 @@
                (track_name VENUE)
                (init
                   {set [zero_length] TRUE}
-                  {set [enabled] {is_ver_30}}
+                  {set [enabled] 
+                     {&& {is_ver_30}
+                           {!{&& {file_exists {sprint "songs/updates/" {meta_performer song} "/" {meta_performer song} "_update.mid"}}
+                            {== {{song_mgr get_meta_data {meta_performer song}} version} 30}}
+                           }
+                     }
+                  } ; This fixes a bug; this is because when the parser was improved, the lights sometimes got stuck due to using the old midi for this.
                   {if {! $dx_venue_lights}
                      {set [enabled] FALSE}
                   }
@@ -2201,7 +2207,13 @@
                (init
                   {set [zero_length] TRUE}
                   {set [legacy_presets] FALSE}
-                  {set [enabled] {! {is_ver_30}}}
+                  {set [enabled]
+                     {|| {! {is_ver_30}}
+                        {&& {file_exists {sprint "songs/updates/" {meta_performer song} "/" {meta_performer song} "_update.mid"}}
+                        {== {{song_mgr get_meta_data {meta_performer song}} version} 30}
+                        {!= $sourcevar ugc2}} ; This is necessary to avoid problems with rbn 2.0 stuff, perhaps unnecessary, but if this causes problems I'll fix it quickly.
+                     }
+                  }
                   {if {! $dx_venue_lights}
                      {set [enabled] FALSE}
                   }


### PR DESCRIPTION
The problem is that when we cleaned up the MIDI files to avoid lighting overlap issues, three events remained in their legacy form: verse = lighting verse, chorus = lighting chorus, and [lighting] = lighting intro. There were two ways to fix this, and this is the most optimal to avoid creating more problems. This should disable the parser in specific cases, as it was originally, but now, taking into account that if a song is updated and is legacy dlc , it disables the new parser and uses the old.