### PR TITLE
Fix protar gem colors

### DIFF
--- a/_ark/dx/overshell/dx_color_states.dta
+++ b/_ark/dx/overshell/dx_color_states.dta
@@ -383,89 +383,89 @@
 
    (dxState_ProtarColorSelector
       (view
-         {if_else {== $dx_protar_color1 0} os_dx_1_green 0}
-         {if_else {== $dx_protar_color1 1} os_dx_1_red 0}
-         {if_else {== $dx_protar_color1 2} os_dx_1_yellow 0}
+         {if_else {== $dx_protar_color1 0} os_dx_1_red 0}
+         {if_else {== $dx_protar_color1 1} os_dx_1_green 0}
+         {if_else {== $dx_protar_color1 2} os_dx_1_orange 0}
          {if_else {== $dx_protar_color1 3} os_dx_1_blue 0}
-         {if_else {== $dx_protar_color1 4} os_dx_1_orange 0}
+         {if_else {== $dx_protar_color1 4} os_dx_1_yellow 0}
          {if_else {== $dx_protar_color1 5} os_dx_1_purple 0}
 
-         {if_else {== $dx_protar_color2 0} os_dx_2_green 0}
-         {if_else {== $dx_protar_color2 1} os_dx_2_red 0}
-         {if_else {== $dx_protar_color2 2} os_dx_2_yellow 0}
+         {if_else {== $dx_protar_color2 0} os_dx_2_red 0}
+         {if_else {== $dx_protar_color2 1} os_dx_2_green 0}
+         {if_else {== $dx_protar_color2 2} os_dx_2_orange 0}
          {if_else {== $dx_protar_color2 3} os_dx_2_blue 0}
-         {if_else {== $dx_protar_color2 4} os_dx_2_orange 0}
+         {if_else {== $dx_protar_color2 4} os_dx_2_yellow 0}
          {if_else {== $dx_protar_color2 5} os_dx_2_purple 0}
 
-         {if_else {== $dx_protar_color3 0} os_dx_3_green 0}
-         {if_else {== $dx_protar_color3 1} os_dx_3_red 0}
-         {if_else {== $dx_protar_color3 2} os_dx_3_yellow 0}
+         {if_else {== $dx_protar_color3 0} os_dx_3_red 0}
+         {if_else {== $dx_protar_color3 1} os_dx_3_green 0}
+         {if_else {== $dx_protar_color3 2} os_dx_3_orange 0}
          {if_else {== $dx_protar_color3 3} os_dx_3_blue 0}
-         {if_else {== $dx_protar_color3 4} os_dx_3_orange 0}
+         {if_else {== $dx_protar_color3 4} os_dx_3_yellow 0}
          {if_else {== $dx_protar_color3 5} os_dx_3_purple 0}
 
-         {if_else {== $dx_protar_color4 0} os_dx_4_green 0}
-         {if_else {== $dx_protar_color4 1} os_dx_4_red 0}
-         {if_else {== $dx_protar_color4 2} os_dx_4_yellow 0}
+         {if_else {== $dx_protar_color4 0} os_dx_4_red 0}
+         {if_else {== $dx_protar_color4 1} os_dx_4_green 0}
+         {if_else {== $dx_protar_color4 2} os_dx_4_orange 0}
          {if_else {== $dx_protar_color4 3} os_dx_4_blue 0}
-         {if_else {== $dx_protar_color4 4} os_dx_4_orange 0}
+         {if_else {== $dx_protar_color4 4} os_dx_4_yellow 0}
          {if_else {== $dx_protar_color4 5} os_dx_4_purple 0}
 
-         {if_else {== $dx_protar_color5 0} os_dx_5_green 0}
-         {if_else {== $dx_protar_color5 1} os_dx_5_red 0}
-         {if_else {== $dx_protar_color5 2} os_dx_5_yellow 0}
+         {if_else {== $dx_protar_color5 0} os_dx_5_red 0}
+         {if_else {== $dx_protar_color5 1} os_dx_5_green 0}
+         {if_else {== $dx_protar_color5 2} os_dx_5_orange 0}
          {if_else {== $dx_protar_color5 3} os_dx_5_blue 0}
-         {if_else {== $dx_protar_color5 4} os_dx_5_orange 0}
+         {if_else {== $dx_protar_color5 4} os_dx_5_yellow 0}
          {if_else {== $dx_protar_color5 5} os_dx_5_purple 0}
 
-         {if_else {== $dx_protar_color6 0} os_dx_6_green 0}
-         {if_else {== $dx_protar_color6 1} os_dx_6_red 0}
-         {if_else {== $dx_protar_color6 2} os_dx_6_yellow 0}
+         {if_else {== $dx_protar_color6 0} os_dx_6_red 0}
+         {if_else {== $dx_protar_color6 1} os_dx_6_green 0}
+         {if_else {== $dx_protar_color6 2} os_dx_6_orange 0}
          {if_else {== $dx_protar_color6 3} os_dx_6_blue 0}
-         {if_else {== $dx_protar_color6 4} os_dx_6_orange 0}
+         {if_else {== $dx_protar_color6 4} os_dx_6_yellow 0}
          {if_else {== $dx_protar_color6 5} os_dx_6_purple 0}
       )
       (select
-         (os_dx_1_green {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
          (os_dx_1_red {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
-         (os_dx_1_yellow {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
-         (os_dx_1_blue {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
+         (os_dx_1_green {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
          (os_dx_1_orange {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
+         (os_dx_1_blue {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
+         (os_dx_1_yellow {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
          (os_dx_1_purple {set $dx_protar_color1 {mod {+ $dx_protar_color1 1} 6}})
 
-         (os_dx_2_green {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
          (os_dx_2_red {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
-         (os_dx_2_yellow {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
-         (os_dx_2_blue {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
+         (os_dx_2_green {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
          (os_dx_2_orange {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
+         (os_dx_2_blue {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
+         (os_dx_2_yellow {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
          (os_dx_2_purple {set $dx_protar_color2 {mod {+ $dx_protar_color2 1} 6}})
 
-         (os_dx_3_green {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
          (os_dx_3_red {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
-         (os_dx_3_yellow {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
-         (os_dx_3_blue {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
+         (os_dx_3_green {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
          (os_dx_3_orange {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
+         (os_dx_3_blue {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
+         (os_dx_3_yellow {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
          (os_dx_3_purple {set $dx_protar_color3 {mod {+ $dx_protar_color3 1} 6}})
 
-         (os_dx_4_green {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
          (os_dx_4_red {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
-         (os_dx_4_yellow {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
-         (os_dx_4_blue {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
+         (os_dx_4_green {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
          (os_dx_4_orange {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
+         (os_dx_4_blue {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
+         (os_dx_4_yellow {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
          (os_dx_4_purple {set $dx_protar_color4 {mod {+ $dx_protar_color4 1} 6}})
 
-         (os_dx_5_green {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
          (os_dx_5_red {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
-         (os_dx_5_yellow {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
-         (os_dx_5_blue {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
+         (os_dx_5_green {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
          (os_dx_5_orange {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
+         (os_dx_5_blue {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
+         (os_dx_5_yellow {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
          (os_dx_5_purple {set $dx_protar_color5 {mod {+ $dx_protar_color5 1} 6}})
 
-         (os_dx_6_green {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
          (os_dx_6_red {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
-         (os_dx_6_yellow {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
-         (os_dx_6_blue {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
+         (os_dx_6_green {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
          (os_dx_6_orange {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
+         (os_dx_6_blue {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
+         (os_dx_6_yellow {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
          (os_dx_6_purple {set $dx_protar_color6 {mod {+ $dx_protar_color6 1} 6}})
       )
       (cancel {dx_state dxState_ColorSelector})


### PR DESCRIPTION
For months the color order was green, red, yellow, blue, orange, purple in overshell, but showed up as red, green, orange, blue, yellow purple in-song (default order). Everything matches now.