### PR TITLE
Show Perfect Percentage in Perfection Mode

### DIFF
--- a/_ark/dx/game/dx_game_reset_funcs.dta
+++ b/_ark/dx/game/dx_game_reset_funcs.dta
@@ -14,7 +14,6 @@
       {set_var {sprint $entry "_finalnote"} FALSE}
       {set_var {sprint $entry "_missed_once"} FALSE}
       {set_var {sprint $entry "_caughtmissed"} FALSE}
-      {set_var {sprint "dx_perfects_count_" $entry} 0}
    }
 }
 {func

--- a/_ark/dx/game/dx_game_reset_funcs.dta
+++ b/_ark/dx/game/dx_game_reset_funcs.dta
@@ -5,16 +5,16 @@
    {set $dx_reported_highscore FALSE}
    {foreach_int $i 0 4
       {set_var {sprint "brutal_number_" $i} -26}
-      {set_var {sprint "dx_perfects_count_" $i} 0}
       {set_var {sprint "dx_stop_od_" $i} FALSE}
       {set_var {sprint "num_gems_combo_" $i} FALSE}
    }
-   {foreach $entry (guitar bass drum keys real_guitar real_bass real_drum real_keys)
+   {foreach $entry (guitar bass drum keys real_guitar real_bass real_drum real_keys vocals harm)
       {set_var {sprint $entry "_milosong"} FALSE}
       {set_var {sprint $entry "_firstnote"} FALSE}
       {set_var {sprint $entry "_finalnote"} FALSE}
       {set_var {sprint $entry "_missed_once"} FALSE}
       {set_var {sprint $entry "_caughtmissed"} FALSE}
+      {set_var {sprint "dx_perfects_count_" $entry} 0}
    }
 }
 {func

--- a/_ark/dx/track/callbacks/dx_track_callbacks.dta
+++ b/_ark/dx/track/callbacks/dx_track_callbacks.dta
@@ -67,7 +67,10 @@
          {thread_task kTaskBeats
             (name {sprint "perfect_task_" [track_instrument]})
             (script
-               {if {&& $dx_perfects_indicator {{[player] get_user} is_local} {== [diff] expert} {gamemode in_mode qp_coop}}
+                {if {||
+                   {&& $dx_perfects_indicator {{[player] get_user} is_local} {== [diff] expert} {gamemode in_mode qp_coop}}
+                   {&& {modifier_enabled mod_perfection} {{[player] get_user} is_local}}
+                }
                   {set [curr_ms] {+ {* {taskmgr seconds} 1000} {profile_mgr get_sync_offset {{[player] get_user} get_pad_num}}}}
                   {set [offset] FALSE}
                   {set [accuracy] -8675309}
@@ -120,7 +123,6 @@
       {set_var {sprint "num_gems_combo_" [slot]} [num_gems_combo]}
       {set_var {sprint "num_gems_pass_" [track_instrument]} [num_gems_pass]}
       {set_var {sprint "num_gems_miss_" [track_instrument]} [num_gems_miss]}
-      {set_var {sprint "dx_perfects_count_" [track_instrument]} [perfects]}
    )
       (check_fc
          {$this check_missed} ;run the logic to check our current misses
@@ -195,19 +197,21 @@
                {if {>= [offset] $dx_window_offset} {set [timing] late}}
                {if {<= [offset] $dx_window_offset} {set [timing] early}}
                ; autoplay is weird and dumb, always show perfects
-               {if_else {modifier_enabled mod_auto_play}
-                  {do
-                     {set [timing] late}
-                     {dx_perfect_hit $dx_perfects_indicator [track_instrument] [player] [slot] $dx_detailed_hit_stats [timing] perfect}
-                     {++ [perfects]} ;increment local counter
-                     {dx_perfect_hit_ctr $dx_perfects_ctr [player] [slot] $dx_detailed_hit_stats [perfects]} ;fire on screen
-                  }
-                  {cond
-                     ({&& {< [offset] {+ 25 $dx_window_offset}} {> [offset] {+ -25 $dx_window_offset}}}
-                        {dx_perfect_hit $dx_perfects_indicator [track_instrument] [player] [slot] $dx_detailed_hit_stats [timing] perfect}
-                        {++ [perfects]} ;increment local counter
-                        {dx_perfect_hit_ctr $dx_perfects_ctr [player] [slot] $dx_detailed_hit_stats [perfects]} ;fire on screen
-                     )
+                {if_else {modifier_enabled mod_auto_play}
+                   {do
+                      {set [timing] late}
+                      {dx_perfect_hit $dx_perfects_indicator [track_instrument] [player] [slot] $dx_detailed_hit_stats [timing] perfect}
+                      {++ [perfects]} ;increment local counter
+                      {set_var {sprint "dx_perfects_count_" [track_instrument]} [perfects]}
+                      {dx_perfect_hit_ctr $dx_perfects_ctr [player] [slot] $dx_detailed_hit_stats [perfects]} ;fire on screen
+                   }
+                   {cond
+                      ({&& {< [offset] {+ 25 $dx_window_offset}} {> [offset] {+ -25 $dx_window_offset}}}
+                         {dx_perfect_hit $dx_perfects_indicator [track_instrument] [player] [slot] $dx_detailed_hit_stats [timing] perfect}
+                         {++ [perfects]} ;increment local counter
+                         {set_var {sprint "dx_perfects_count_" [track_instrument]} [perfects]}
+                         {dx_perfect_hit_ctr $dx_perfects_ctr [player] [slot] $dx_detailed_hit_stats [perfects]} ;fire on screen
+                      )
                      ({&& {< [offset] {+ 40 $dx_window_offset}} {> [offset] {+ -40 $dx_window_offset}}}
                         {dx_perfect_hit $dx_perfects_indicator [track_instrument] [player] [slot] $dx_detailed_hit_stats [timing] great}
                      )

--- a/_ark/dx/track/callbacks/dx_track_callbacks.dta
+++ b/_ark/dx/track/callbacks/dx_track_callbacks.dta
@@ -47,7 +47,7 @@
 }
 {func dx_create_instrument_callback
    ($instrument $player $slot)
-   {set_var {sprint "dx_perfects_count_" $player} 0} ;shove this here so it resets for a player when callback is added
+   {set_var {sprint "dx_perfects_count_" $instrument} 0} ;shove this here so it resets for a player when callback is added
    {if {exists {sprint "fc_" $instrument "_callback"}} ;delete the object and recreate it if already exists
       {delete {sprint "fc_" $instrument "_callback"}}
    }
@@ -115,12 +115,13 @@
             {set_var {sprint [track_instrument] "_firstnote"} TRUE}
          }
       )
-      (store_note_hit_info
-         {set_var {sprint "num_gems_hit_" [track_instrument]} [num_gems_hit]}
-         {set_var {sprint "num_gems_combo_" [slot]} [num_gems_combo]}
-         {set_var {sprint "num_gems_pass_" [track_instrument]} [num_gems_pass]}
-         {set_var {sprint "num_gems_miss_" [track_instrument]} [num_gems_miss]}
-      )
+   (store_note_hit_info
+      {set_var {sprint "num_gems_hit_" [track_instrument]} [num_gems_hit]}
+      {set_var {sprint "num_gems_combo_" [slot]} [num_gems_combo]}
+      {set_var {sprint "num_gems_pass_" [track_instrument]} [num_gems_pass]}
+      {set_var {sprint "num_gems_miss_" [track_instrument]} [num_gems_miss]}
+      {set_var {sprint "dx_perfects_count_" [track_instrument]} [perfects]}
+   )
       (check_fc
          {$this check_missed} ;run the logic to check our current misses
          {if {&& $dx_fc_glow {== {'+' [num_gems_pass] [num_gems_miss]} 0}} ;if on fc

--- a/_ark/dx/ui/dx_ui_init.dta
+++ b/_ark/dx/ui/dx_ui_init.dta
@@ -175,8 +175,8 @@ DX_CURRENT_SONG_CLEAR
 {set $dx_track_perfect_ctr_r 1}
 {set $dx_track_perfect_ctr_g 1}
 {set $dx_track_perfect_ctr_b 1}
-{foreach_int $i 0 3
-   {set_var {sprint "dx_perfects_count_" $i} 0}
+{foreach $entry (guitar bass drum keys real_guitar real_bass real_drum real_keys vocals harm)
+   {set_var {sprint "dx_perfects_count_" $entry} 0}
 }
 {set $dx_list_pos 0}
 {set $dx_list_item_selected FALSE}

--- a/_ark/ui/endgame/endgame_helpers.dta
+++ b/_ark/ui/endgame/endgame_helpers.dta
@@ -170,7 +170,18 @@
                               {== $icon $dx_icon_keys} {== $icon $dx_icon_real_keys}
                            }
                         )
-                        ($percent {dx_round_percent {'*' 100 {{$user player} notes_hit_fraction}}})
+                        ($percent {dx_round_percent
+                           {if_else
+                              {&& {modifier_mgr is_modifier_active mod_perfection} $pass}
+                              {'*' 100
+                                 {/
+                                    {eval {var {sprint "dx_perfects_count_" {$player instrument}}}}
+                                    {if_else {> {$player get_gem_count} 0} {$player get_gem_count} 1}
+                                 }
+                              }
+                              {'*' 100 {{$user player} notes_hit_fraction}}
+                           }
+                        })
                         ($diff_sym {$user get_difficulty_sym})
                         ($diff {localize {sprint $diff_sym "_short"}})
                         {player_details.lbl set_intro_name $user}
@@ -187,6 +198,7 @@
                                     {modifier_mgr is_modifier_active mod_precision}
                                     {modifier_mgr is_modifier_active mod_calibration}
                                     {modifier_mgr is_modifier_active mod_chmode}
+                                    {modifier_mgr is_modifier_active mod_perfection}
                                  }
                                  $pass
                               }


### PR DESCRIPTION
When in Perfection Mode, the percentage indicator at the end isn't all that useful, because it's _always_ 100% if you make it to the end.
This PR aims to show the percentage of perfect notes over notes hit. It also adds the Perfect indicator to other difficulties when in Perfection mode.

I opened this PR for others to see as maybe someone else knows how to fix it up or test it easily. I am still not sure how to navigate all these scripts, and likely have broken something.

Here are some oddities I ran into in the current draft
- The percentage sometimes has difficulty in it, sometimes not
  - Example, sometimes I saw "100%", and sometimes "0.00% E" (easy)
- On the song I was sampling, I was not able to produce a "Perfect" note on Easy mode for Guitar, but I could (very reliably) on Bass
