### PR TITLE
Fix search cache generation crash with RB3Enhanced (issue #1301)

### DIFF
--- a/_ark/dx/ui/dx_search_funcs.dta
+++ b/_ark/dx/ui/dx_search_funcs.dta
@@ -112,7 +112,17 @@
             ($node {music_library get_highlighted_node})
             ($shortname "blank")
             ($shortname_str "blank")
-            {if {== {$node get_node_type} kNodeSong}
+            ; RB3E compat (issue #1301): with RB3Enhanced loaded, get_highlighted_node
+            ; can return a null object on some rows (letter headers). Dispatching any
+            ; message to a null object hard-crashes the game (null handle inside
+            ; DataArray::Execute). Re-apply the highlight and re-fetch once, then
+            ; skip the row if the node is still null. Headers carry no song data,
+            ; so skipping them is lossless.
+            {if {! $node}
+                {music_library set_highlight_ix $searchcache_curdata FALSE}
+                {set $node {music_library get_highlighted_node}}
+            }
+            {if {&& $node {== {$node get_node_type} kNodeSong}}
                 ;{song_select_panel dx_authorpoll {$node get_token}}
                 ; Author finder is too slow
                 {set $shortname {$node get_token}}
@@ -180,7 +190,8 @@
         {music_library set_highlight_ix $i FALSE}
         {do
             ($node {music_library get_highlighted_node})
-            {if {== {$node get_node_type} kNodeSong}
+            ; RB3E compat: guard against null nodes (see issue #1301)
+            {if {&& $node {== {$node get_node_type} kNodeSong}}
                 {do
                     ($uppername {$node title})
                     ($name {tolower $uppername})

--- a/_ark/dx/ui/dx_search_funcs.dta
+++ b/_ark/dx/ui/dx_search_funcs.dta
@@ -112,12 +112,6 @@
             ($node {music_library get_highlighted_node})
             ($shortname "blank")
             ($shortname_str "blank")
-            ; RB3E compat (issue #1301): with RB3Enhanced loaded, get_highlighted_node
-            ; can return a null object on some rows (letter headers). Dispatching any
-            ; message to a null object hard-crashes the game (null handle inside
-            ; DataArray::Execute). Re-apply the highlight and re-fetch once, then
-            ; skip the row if the node is still null. Headers carry no song data,
-            ; so skipping them is lossless.
             {if {! $node}
                 {music_library set_highlight_ix $searchcache_curdata FALSE}
                 {set $node {music_library get_highlighted_node}}
@@ -190,7 +184,6 @@
         {music_library set_highlight_ix $i FALSE}
         {do
             ($node {music_library get_highlighted_node})
-            ; RB3E compat: guard against null nodes (see issue #1301)
             {if {&& $node {== {$node get_node_type} kNodeSong}}
                 {do
                     ($uppername {$node title})

--- a/_ark/ui/song_select/song_select.dta
+++ b/_ark/ui/song_select/song_select.dta
@@ -136,10 +136,6 @@
             {delete author_finder}
          }
          {do
-            ; RB3E compat (issue #1301): this handler polls every frame on RB3E
-            ; builds and the highlighted node can be a null object while search
-            ; cache generation sweeps the library -- bind once and null-check
-            ; before dispatching to it
             ($node {music_library get_highlighted_node})
             {if {&& $probe $node {== {$node get_node_type} kNodeSong}}
                {do
@@ -170,9 +166,6 @@
                #endif
                (name author_finder)
                (script
-                  ; RB3E compat (issue #1301): on RB3E builds this task fires with
-                  ; no delay; re-fetch and guard the node at fire time -- the
-                  ; highlight may have moved (or gone null) since scheduling
                   {do
                      ($af_node {music_library get_highlighted_node})
                      {if {&& $af_node {== {$af_node get_node_type} kNodeSong}}

--- a/_ark/ui/song_select/song_select.dta
+++ b/_ark/ui/song_select/song_select.dta
@@ -135,17 +135,24 @@
          {if {exists author_finder}
             {delete author_finder}
          }
-         {if {&& $probe {== {{music_library get_highlighted_node} get_node_type} kNodeSong}}
-            {do
-               ($token {{music_library get_highlighted_node} get_token})
-               ($song_path {sprint {song_mgr song_path $token} "/../../gen/songs.dtb"})
-               {if
-                  {||
-                     {file_exists $song_path}
-                     {song_mgr is_song_mounted $token}
+         {do
+            ; RB3E compat (issue #1301): this handler polls every frame on RB3E
+            ; builds and the highlighted node can be a null object while search
+            ; cache generation sweeps the library -- bind once and null-check
+            ; before dispatching to it
+            ($node {music_library get_highlighted_node})
+            {if {&& $probe $node {== {$node get_node_type} kNodeSong}}
+               {do
+                  ($token {$node get_token})
+                  ($song_path {sprint {song_mgr song_path $token} "/../../gen/songs.dtb"})
+                  {if
+                     {||
+                        {file_exists $song_path}
+                        {song_mgr is_song_mounted $token}
+                     }
+                     {set $probeforfinder FALSE}
+                     {$this dx_authorfinder}
                   }
-                  {set $probeforfinder FALSE}
-                  {$this dx_authorfinder}
                }
             }
          }
@@ -163,8 +170,16 @@
                #endif
                (name author_finder)
                (script
-                  {$this dx_authorpoll {{music_library get_highlighted_node} get_token}}
-                  {$this apply_authorfinder_metadata}
+                  ; RB3E compat (issue #1301): on RB3E builds this task fires with
+                  ; no delay; re-fetch and guard the node at fire time -- the
+                  ; highlight may have moved (or gone null) since scheduling
+                  {do
+                     ($af_node {music_library get_highlighted_node})
+                     {if {&& $af_node {== {$af_node get_node_type} kNodeSong}}
+                        {$this dx_authorpoll {$af_node get_token}}
+                        {$this apply_authorfinder_metadata}
+                     }
+                  }
                )
             }
          }


### PR DESCRIPTION
On RB3E builds, song_select_panel's (poll) handler gate compiles to TRUE (#ifdef RB3E), so dx_more_info_load runs on every poll tick once any SCROLL_MSG arms $probeforfinder. Search cache generation arms it constantly: each set_highlight_ix updates the list selection, raising SCROLL_MSG, and UIList::SetSelectedSimulateScroll polls the panel synchronously mid-sweep. While the list is scrolling the handler takes its safe branch; when the list settles -- the end of each batch of 20 rows -- it dispatched get_node_type to a raw
{music_library get_highlighted_node} with no null check. When the sweep settles on a non-song row the node can be a null object, and retail DataArray::Execute dispatches to it without the debug build's null guard: a deterministic null read inside DataArray::Execute, identical in every crash dump. Vanilla builds compile the poll gate to a normally-false condition, which is why generation only crashes with RB3Enhanced loaded.

Three guards fix it:

1. dx_more_info_load binds the node once and null-checks it before dispatching (the primary crash site).
2. The author_finder script_task -- which has no delay on RB3E builds and re-fetches the node at fire time -- guards its re-fetch the same way (same crash one task tick later).
3. dx_generate_search_cache_iteration guards its own dispatch: the nested poll runs inside set_highlight_ix, so a null seen by the poll is still the current node when the iteration fetches it. If the node is null it re-applies the highlight and re-fetches once (so a real song is never silently dropped from the cache), then skips the row if still null. The same guard is applied to the Wii dx_song_search path, which has the identical latent pattern.

Verified against the RB3 decompilation: DataAnd short-circuits on the first falsy argument and DataNode::NotNull is false for a null object node, so get_node_type is never dispatched to null. Validated on RGH Xbox 360 hardware: generation completes with these guards and no other changes; crash dumps (C0000005 null read at DataArray::Execute, evaluated node = {value NULL, type OBJECT} in the engine's static evaluation storage) fingerprint the nested-command dispatch shape of the guarded sites.

Credit to DragRedSim for the investigation that localized the crash to frames settling on non-song rows (workaround_search_cache_crash); this supersedes that workaround by guarding the actual crash sites.